### PR TITLE
fix: validate required environment variables before startup

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,6 +1,9 @@
 const dotenv = require('dotenv');
 dotenv.config();
 
+const validateEnv = require('./utils/validateEnv');
+validateEnv();
+
 const express = require('express')
 const mongoose = require('mongoose')
 const cors = require('cors')

--- a/backend/utils/validateEnv.js
+++ b/backend/utils/validateEnv.js
@@ -1,0 +1,13 @@
+const requiredEnvVars = ["MONGO_URL", "PORT", "REDIS_URL"];
+
+function validateEnv() {
+  const missing = requiredEnvVars.filter((key) => !process.env[key]);
+
+  if (missing.length) {
+    console.error("❌ Missing required environment variables:");
+    missing.forEach((key) => console.error(`   - ${key}`));
+    process.exit(1);
+  }
+}
+
+module.exports = validateEnv;


### PR DESCRIPTION
Added a centralized validation step for required environment variables.

The app now checks for MONGO_URL, PORT, and REDIS_URL during initialization.  
If any variable is missing, it logs a clear error and exits early, preventing unexpected runtime crashes in dependent modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Application now validates required environment variables at startup and exits with an error if any are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->