### PR TITLE
test: add smoke test for GET / endpoint

### DIFF
--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,22 +1,16 @@
-process.env.REDIS_URL = "redis://localhost:6379"
-jest.mock('ioredis', () => {
-    return jest.fn().mockImplementation(() => ({
-        on: jest.fn(),
-        quit: jest.fn().mockResolvedValue('OK'),
-        status: 'ready'
-    }));
-});
 
 const app = require('../app')
 const request = require('supertest')
 
 
-describe("Health endpoint test",()=>{
+describe("Health endpoint test and health payload",()=>{
     it("GET / return 200",async()=>{
         const res = await request(app).get("/");
 
         expect(res.status).toBe(200);
-        expect(res.body.status).toBe("success")
-        expect(res.body.message).toBe("urBackend API is running 🚀")
+        expect(res.body).toEqual({
+        status: "success",
+        message: "urBackend API is running 🚀"
+        })
     })
 })

--- a/backend/tests/jest.setup.js
+++ b/backend/tests/jest.setup.js
@@ -1,4 +1,7 @@
 
+process.env.REDIS_URL = "redis://localhost:6379"
+
+
 jest.mock('ioredis', () => {
     const Redis = jest.fn().mockImplementation(() => ({
         on: jest.fn(),


### PR DESCRIPTION
Adds a basic smoke test for the root endpoint.

What this PR does:
- adds a test for GET /
- verifies response status is 200
- verifies response body contains status: "success"

Local verification:
```bash
npx jest tests/health.test.js --testTimeout=10000 --setupFiles ./tests/jest.setup.js
```

The test passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added backend test to verify the health-check endpoint returns a successful status and the expected message.
* **Chores**
  * Test environment now sets a Redis connection URL for local test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->