### PR TITLE
feat: add client.db.count() method for counting collection documents

### DIFF
--- a/apps/public-api/src/controllers/data.controller.js
+++ b/apps/public-api/src/controllers/data.controller.js
@@ -125,10 +125,10 @@ module.exports.getAllData = async (req, res) => {
     // Handle count=true query parameter
 if (req.query.count === 'true') {
   const countEngine = new QueryEngine(Model.find(), req.query);
-  const mongoFilter = countEngine.filter().query.getFilter();
-  const mergedFilter = Object.keys(baseFilter).length > 0
-    ? { ...mongoFilter, ...baseFilter }
-    : mongoFilter;
+const mongoFilter = countEngine._buildMongoQuery(true);
+const mergedFilter = Object.keys(baseFilter).length > 0
+  ? { $and: [mongoFilter, baseFilter] }
+  : mongoFilter;
   const count = await Model.countDocuments(mergedFilter);
   return res.status(200).json({ success: true, data: { count }, message: "Count fetched successfully." });
 }

--- a/apps/public-api/src/controllers/data.controller.js
+++ b/apps/public-api/src/controllers/data.controller.js
@@ -125,12 +125,12 @@ module.exports.getAllData = async (req, res) => {
     // Handle count=true query parameter
 if (req.query.count === 'true') {
   const countEngine = new QueryEngine(Model.find(), req.query);
-  let countQuery = countEngine.count().query;
-  if (Object.keys(baseFilter).length > 0) {
-    countQuery = Model.countDocuments({ ...countQuery.getFilter?.() ?? {}, ...baseFilter });
-  }
-  const count = await countQuery;
-  return res.json({ count });
+  const mongoFilter = countEngine.filter().query.getFilter();
+  const mergedFilter = Object.keys(baseFilter).length > 0
+    ? { ...mongoFilter, ...baseFilter }
+    : mongoFilter;
+  const count = await Model.countDocuments(mergedFilter);
+  return res.status(200).json({ success: true, data: { count }, message: "Count fetched successfully." });
 }
     const features = new QueryEngine(Model.find(), req.query)
       .filter();

--- a/apps/public-api/src/controllers/data.controller.js
+++ b/apps/public-api/src/controllers/data.controller.js
@@ -122,6 +122,16 @@ module.exports.getAllData = async (req, res) => {
     );
 
     const baseFilter = req.rlsFilter && typeof req.rlsFilter === 'object' ? req.rlsFilter : {};
+    // Handle count=true query parameter
+if (req.query.count === 'true') {
+  const countEngine = new QueryEngine(Model.find(), req.query);
+  let countQuery = countEngine.count().query;
+  if (Object.keys(baseFilter).length > 0) {
+    countQuery = Model.countDocuments({ ...countQuery.getFilter?.() ?? {}, ...baseFilter });
+  }
+  const count = await countQuery;
+  return res.json({ count });
+}
     const features = new QueryEngine(Model.find(), req.query)
       .filter();
 

--- a/packages/common/src/utils/queryEngine.js
+++ b/packages/common/src/utils/queryEngine.js
@@ -71,11 +71,6 @@ class QueryEngine {
         });
         return this;
     }
-
-    async count() {
-        // Clone the query to avoid affecting the original query's skip/limit
-        return await this.query.model.countDocuments(this.query.getQuery());
-    }
 }
 
 module.exports = QueryEngine;

--- a/packages/common/src/utils/queryEngine.js
+++ b/packages/common/src/utils/queryEngine.js
@@ -71,6 +71,44 @@ class QueryEngine {
         });
         return this;
     }
+
+<<<<<<< HEAD
+    async count() {
+        // Clone the query to avoid affecting the original query's skip/limit
+        return await this.query.model.countDocuments(this.query.getQuery());
+    }
+=======
+   _buildMongoQuery(excludeCount = false) {
+    const queryObj = { ...this.queryString };
+    const excludedFields = ['page', 'sort', 'limit', 'fields', 'populate', 'expand'];
+    if (excludeCount) excludedFields.push('count');
+    excludedFields.forEach(el => delete queryObj[el]);
+    const mongoQuery = {};
+    for (const key in queryObj) {
+        if (key.endsWith('_gt')) {
+            const field = key.replace(/_gt$/, '');
+            mongoQuery[field] = { ...mongoQuery[field], $gt: queryObj[key] };
+        } else if (key.endsWith('_gte')) {
+            const field = key.replace(/_gte$/, '');
+            mongoQuery[field] = { ...mongoQuery[field], $gte: queryObj[key] };
+        } else if (key.endsWith('_lt')) {
+            const field = key.replace(/_lt$/, '');
+            mongoQuery[field] = { ...mongoQuery[field], $lt: queryObj[key] };
+        } else if (key.endsWith('_lte')) {
+            const field = key.replace(/_lte$/, '');
+            mongoQuery[field] = { ...mongoQuery[field], $lte: queryObj[key] };
+        } else {
+            mongoQuery[key] = queryObj[key];
+        }
+    }
+    return mongoQuery;
+}
+
+count() {
+    this.query = this.query.model.countDocuments(this._buildMongoQuery(true));
+    return this;
+}
+>>>>>>> 3fb84f3e (feat: implement native client.db.count() support)
 }
 
 module.exports = QueryEngine;

--- a/sdks/urbackend-sdk/package.json
+++ b/sdks/urbackend-sdk/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@urbackend/sdk",
+<<<<<<< HEAD
   "version": "0.2.6",
+=======
+  "version": "0.2.3",
+>>>>>>> 806126af (chore: bump sdk version to 0.2.3)
   "description": "Official TypeScript SDK for urBackend BaaS",
   "type": "module",
   "files": [

--- a/sdks/urbackend-sdk/package.json
+++ b/sdks/urbackend-sdk/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@urbackend/sdk",
 <<<<<<< HEAD
+<<<<<<< HEAD
   "version": "0.2.6",
 =======
   "version": "0.2.3",
 >>>>>>> 806126af (chore: bump sdk version to 0.2.3)
+=======
+  "version": "0.2.7",
+>>>>>>> 99b31f75 (chore: bump sdk version to 0.2.7)
   "description": "Official TypeScript SDK for urBackend BaaS",
   "type": "module",
   "files": [

--- a/sdks/urbackend-sdk/package.json
+++ b/sdks/urbackend-sdk/package.json
@@ -1,14 +1,6 @@
 {
   "name": "@urbackend/sdk",
-<<<<<<< HEAD
-<<<<<<< HEAD
-  "version": "0.2.6",
-=======
-  "version": "0.2.3",
->>>>>>> 806126af (chore: bump sdk version to 0.2.3)
-=======
   "version": "0.2.7",
->>>>>>> 99b31f75 (chore: bump sdk version to 0.2.7)
   "description": "Official TypeScript SDK for urBackend BaaS",
   "type": "module",
   "files": [

--- a/sdks/urbackend-sdk/src/modules/database.ts
+++ b/sdks/urbackend-sdk/src/modules/database.ts
@@ -23,6 +23,16 @@ export class DatabaseModule {
   }
 
   /**
+ * Count documents in a collection with optional filters
+ */
+public async count(collection: string, params: Omit<QueryParams, 'count'> = {}): Promise<number> {
+  const queryString = this.buildQueryString({ ...params, count: 'true' });
+  const path = `/api/data/${collection}${queryString}`;
+  const result = await this.client.request<{ count: number }>('GET', path);
+  return result.count;
+}
+
+  /**
    * Fetch a single document by its ID
    */
   public async getOne<T extends DocumentData>(

--- a/sdks/urbackend-sdk/tests/database.test.ts
+++ b/sdks/urbackend-sdk/tests/database.test.ts
@@ -132,3 +132,49 @@ test('delete returns { deleted: true } and handles token', async () => {
     }),
   );
 });
+
+test('count returns total number of documents in a collection', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => Promise.resolve({ success: true, data: { count: 42 } }),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const result = await client.db.count('products');
+
+  expect(result).toBe(42);
+  const url = fetchMock.mock.calls[0][0] as string;
+  const searchParams = new URL(url).searchParams;
+  expect(searchParams.get('count')).toBe('true');
+});
+
+test('count with filters builds correct query string', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => Promise.resolve({ success: true, data: { count: 7 } }),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const result = await client.db.count('products', { filter: { status: 'active' } });
+
+  expect(result).toBe(7);
+  const url = fetchMock.mock.calls[0][0] as string;
+  const searchParams = new URL(url).searchParams;
+  expect(searchParams.get('count')).toBe('true');
+  expect(searchParams.get('status')).toBe('active');
+});
+
+test('count returns 0 when no documents match', async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: () => Promise.resolve({ success: true, data: { count: 0 } }),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const result = await client.db.count('products', { filter: { status: 'deleted' } });
+
+  expect(result).toBe(0);
+});


### PR DESCRIPTION
## What's the problem?

There was no efficient way to get the number of documents in a collection. You had to do something like this:

```js
const all = await client.db.getAll('products');
const count = all.length; // fetches everything just to count
```

This is wasteful especially when you have thousands of records.

---

## What I changed

**Backend (`data.controller.js` + `queryEngine.js`)**

Added a check for `?count=true` query param in the controller. When present, instead of fetching all documents, it runs `countDocuments()` and returns `{ count: number }`. Also added a `count()` method to `QueryEngine` so filters still work properly when counting.

**SDK (`database.ts`)**

Added a `count()` method to `DatabaseModule`. It passes `count=true` to the API and just returns the number back. Used `Omit<QueryParams, 'count'>` on the params type so nobody accidentally passes count as a filter field.

**Tests (`database.test.ts`)**

Added 3 new tests:
- Count all documents in a collection
- Count with filters (e.g only active items)
- Count returns 0 when nothing matches

---

## Usage

```js
const total = await client.db.count('products');
const active = await client.db.count('products', { filter: { status: 'active' } });
```

---

## Tests

All 22 tests passing.

Closes #94.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Count API: retrieve the total number of records in a collection without fetching items.
  * SDK: new count method to request record counts directly from client code.

* **Tests**
  * Added tests validating count behavior and query construction for count requests.

* **Chores**
  * SDK package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->