### PR TITLE
feat(validation): add custom regex support for url, color, slug formats

### DIFF
--- a/packages/common/src/utils/validateData.js
+++ b/packages/common/src/utils/validateData.js
@@ -26,7 +26,6 @@ const buildIncomingMaps = (incomingData = {}) => {
 };
 
 // Recursive data validator for schema fields
-// Returns error string or null if valid
 function validateField(value, field) {
     if (field.required && (value === undefined || value === null)) {
         return `Field '${field.key}' is required.`;
@@ -35,28 +34,40 @@ function validateField(value, field) {
 
     switch (field.type) {
         case 'String':
-            if (typeof value !== 'string') return `Field '${field.key}' must be a String.`;
+            if (typeof value !== 'string') {
+                return `Field '${field.key}' must be a String.`;
+            }
+
             if (field.format) {
                 const regex = FORMAT_REGEX[field.format];
-                const trimmedValue = value.trim();
-                if (regex && !regex.test(trimmedValue)) {
+
+                if (regex && !regex.test(value)) {
                     if (field.format === 'email') {
                         return `Field '${field.key}' must be a valid email (e.g., user@example.com).`;
-                    } else {
-                        return `Field '${field.key}' must match format '${field.format}'.`;
                     }
+                    return `Field '${field.key}' must match format '${field.format}'.`;
                 }
             }
             break;
+
         case 'Number':
-            if (typeof value !== 'number') return `Field '${field.key}' must be a Number.`;
+            if (typeof value !== 'number') {
+                return `Field '${field.key}' must be a Number.`;
+            }
             break;
+
         case 'Boolean':
-            if (typeof value !== 'boolean') return `Field '${field.key}' must be a Boolean.`;
+            if (typeof value !== 'boolean') {
+                return `Field '${field.key}' must be a Boolean.`;
+            }
             break;
+
         case 'Date':
-            if (isNaN(Date.parse(value))) return `Field '${field.key}' must be a valid Date.`;
+            if (isNaN(Date.parse(value))) {
+                return `Field '${field.key}' must be a valid Date.`;
+            }
             break;
+
         case 'Object':
             if (typeof value !== 'object' || Array.isArray(value)) {
                 return `Field '${field.key}' must be an Object.`;
@@ -68,6 +79,7 @@ function validateField(value, field) {
                 }
             }
             break;
+
         case 'Array':
             if (!Array.isArray(value)) {
                 return `Field '${field.key}' must be an Array.`;
@@ -85,57 +97,70 @@ function validateField(value, field) {
                 }
             }
             break;
+
         case 'Ref':
             if (typeof value !== 'string' || !mongoose.Types.ObjectId.isValid(value)) {
                 return `Field '${field.key}' must be a valid reference ID (ObjectId).`;
             }
             break;
     }
+
     return null;
 }
 
 // Validate incoming data against schema rules
-// Returns { error } or { cleanData }
 function validateData(incomingData, schemaRules) {
-    const cleanData = { ...incomingData }; // Start with all data
+    const cleanData = { ...incomingData };
     const { normalizedValueMap } = buildIncomingMaps(incomingData);
 
     for (const field of schemaRules) {
         const fieldKey = normalizeKey(field.key);
-        const value = normalizedValueMap.has(fieldKey)
+        let value = normalizedValueMap.has(fieldKey)
             ? normalizedValueMap.get(fieldKey)
             : incomingData[field.key];
 
+        // ✅ FIX: trim BEFORE validation and storage
+        if (field.type === 'String' && typeof value === 'string') {
+            value = value.trim();
+        }
+
         const error = validateField(value, field);
         if (error) return { error };
-
 
         if (value !== undefined) {
             cleanData[field.key] = value;
         }
     }
+
     return { cleanData };
 }
 
-// Validate partial update data (non-required fields can be missing)
+// Validate partial update data
 function validateUpdateData(incomingData, schemaRules) {
-    const updateData = { ...incomingData }; // Start with all data
+    const updateData = { ...incomingData };
     const { normalizedValueMap } = buildIncomingMaps(incomingData);
     const normalizedSchemaMap = new Map(
         schemaRules.map((f) => [normalizeKey(f.key), f])
     );
 
-    for (const [normalizedKey, value] of normalizedValueMap.entries()) {
+    for (const [normalizedKey, valueRaw] of normalizedValueMap.entries()) {
         const fieldRule = normalizedSchemaMap.get(normalizedKey);
-        if (!fieldRule) continue; // Allow extra fields
+        if (!fieldRule) continue;
 
-        // For updates, don't enforce 'required' — only validate type
+        let value = valueRaw;
+
+        // ✅ FIX here also
+        if (fieldRule.type === 'String' && typeof value === 'string') {
+            value = value.trim();
+        }
+
         const tempField = { ...fieldRule, required: false };
         const error = validateField(value, tempField);
         if (error) return { error };
 
         updateData[fieldRule.key] = value;
     }
+
     return { updateData };
 }
 

--- a/packages/common/src/utils/validateData.js
+++ b/packages/common/src/utils/validateData.js
@@ -2,9 +2,12 @@ const mongoose = require('mongoose');
 
 const FORMAT_REGEX = {
     email: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
-    url: /^https?:\/\/.+$/,
+
+    url: /^(https?:\/\/)([\w-]+(\.[\w-]+)+)(:\d+)?(\/[\w\-.~:/?#[\]@!$&'()*+,;=%]*)?$/,
+
     color: /^#[0-9A-Fa-f]{6}$/,
-    slug: /^[a-z0-9-]+$/,
+
+    slug: /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
 };
 
 const normalizeKey = (key) => String(key || '').replace(/\uFEFF/g, '').trim();

--- a/packages/common/src/utils/validateData.js
+++ b/packages/common/src/utils/validateData.js
@@ -1,5 +1,12 @@
 const mongoose = require('mongoose');
 
+const FORMAT_REGEX = {
+    email: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
+    url: /^https?:\/\/.+$/,
+    color: /^#[0-9A-Fa-f]{6}$/,
+    slug: /^[a-z0-9-]+$/,
+};
+
 const normalizeKey = (key) => String(key || '').replace(/\uFEFF/g, '').trim();
 
 const buildIncomingMaps = (incomingData = {}) => {
@@ -29,6 +36,17 @@ function validateField(value, field) {
     switch (field.type) {
         case 'String':
             if (typeof value !== 'string') return `Field '${field.key}' must be a String.`;
+            if (field.format) {
+                const regex = FORMAT_REGEX[field.format];
+                const trimmedValue = value.trim();
+                if (regex && !regex.test(trimmedValue)) {
+                    if (field.format === 'email') {
+                        return `Field '${field.key}' must be a valid email (e.g., user@example.com).`;
+                    } else {
+                        return `Field '${field.key}' must match format '${field.format}'.`;
+                    }
+                }
+            }
             break;
         case 'Number':
             if (typeof value !== 'number') return `Field '${field.key}' must be a Number.`;


### PR DESCRIPTION
### Summary
Enhanced the validation system by adding support for additional string formats in the schema builder.

### Changes
- Added FORMAT_REGEX registry for reusable validation patterns
- Implemented support for:
  - URL (http/https)
  - Email (improved error messaging)
  - Color (hex format #FFFFFF)
  - Slug (lowercase alphanumeric with hyphens)
- Extended validation logic inside `validateField` for String type
- Ensured backward compatibility by skipping unknown formats

### Behavior
- Invalid formatted inputs now return clear validation errors (400)
- Existing validation logic remains unaffected

### Testing
- Tested using direct function execution (unit-style)
- Verified invalid inputs are rejected
- Verified valid inputs pass
- Ensured unknown formats do not crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for email, URL, color, and slug formats with format-specific error messages.
* **Bug Fixes / Improvements**
  * String inputs are now trimmed before validation and before being saved, reducing accidental whitespace failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->