### PR TITLE
feat: add API performance analytics (latency + error rate)

### DIFF
--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -2050,11 +2050,10 @@ const errorRate = analyticsAgg[0] ? (analyticsAgg[0].errors / analyticsAgg[0].to
       },
       message: 'Analytics fetched successfully.',
     });
-  } catch (err) {
+ } catch (err) {
     console.error('Analytics error:', err);
     return next(new AppError(500, 'Failed to fetch analytics.'));
-  }
-};
+}};
 // FUNCTION - TOGGLE AUTH
 module.exports.toggleAuth = async (req, res) => {
   try {

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -34,8 +34,8 @@ const { verifyUploadedFile } = require("@urbackend/common");
 const { getPublicIp } = require("@urbackend/common");
 const { clearCompiledModel } = require("@urbackend/common");
 const { createUniqueIndexes } = require("@urbackend/common");
-const ApiAnalytics = require('@urbackend/common').ApiAnalytics; // ADDED for analytics
-
+ // ADDED for analytics
+const ApiAnalytics = require('@urbackend/common').ApiAnalytics;
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 const SAFETY_MAX_BYTES = 100 * 1024 * 1024;
 const CONFIRM_UPLOAD_SIZE_TOLERANCE_BYTES = 64;
@@ -1964,18 +1964,21 @@ module.exports.deleteProject = async (req, res) => {
 module.exports.analytics = async (req, res) => {
   try {
     const { projectId } = req.params;
-    const { range = 'last24h' } = req.query; // new query parameter
+    const { range = 'last24h' } = req.query;
 
     const project = await Project.findOne({
       _id: projectId,
       owner: req.user._id,
     });
-    if (!project)
-      return res
-        .status(404)
-        .json({ error: "Project not found or access denied." });
+    if (!project) {
+      return res.status(404).json({
+        success: false,
+        data: {},
+        message: "Project not found or access denied.",
+      });
+    }
 
-    // --- Existing analytics (storage, database, logs, chartData) ---
+    // --- Existing analytics ---
     const totalRequests = await Log.countDocuments({ projectId });
     const logs = await Log.find({ projectId })
       .sort({ timestamp: -1 })
@@ -2044,20 +2047,28 @@ module.exports.analytics = async (req, res) => {
     ]);
     const errorRate = errorAgg[0] ? (errorAgg[0].errors / errorAgg[0].total) * 100 : 0;
 
-    // --- Response (merge existing + new metrics) ---
+    // --- Response with correct format ---
     res.json({
-      storage: { used: project.storageUsed, limit: project.storageLimit },
-      database: { used: project.databaseUsed, limit: project.databaseLimit },
-      totalRequests,
-      logs,
-      chartData,
-      avgResponseTimeMs,   // new
-      errorRate,           // new
-      range,               // optional – echo the requested range
+      success: true,
+      data: {
+        storage: { used: project.storageUsed, limit: project.storageLimit },
+        database: { used: project.databaseUsed, limit: project.databaseLimit },
+        totalRequests,
+        logs,
+        chartData,
+        avgResponseTimeMs,
+        errorRate,
+        range,
+      },
+      message: "Analytics fetched successfully",
     });
   } catch (err) {
     console.error('Analytics error:', err);
-    res.status(500).json({ error: err.message });
+    res.status(500).json({
+      success: false,
+      data: {},
+      message: err.message || "Failed to fetch analytics",
+    });
   }
 };
 

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -1959,7 +1959,7 @@ module.exports.deleteProject = async (req, res) => {
 };
 
 // MODIFIED analytics function to include API performance metrics
-module.exports.analytics = async (req, res) => {
+module.exports.analytics = async (req, res, next) => {
   try {
     const { projectId } = req.params;
     const { range = 'last24h' } = req.query;
@@ -2029,7 +2029,7 @@ module.exports.analytics = async (req, res) => {
     const errorRate = errorAgg[0] ? (errorAgg[0].errors / errorAgg[0].total) * 100 : 0;
 
     // ✅ Correct response format
-    res.json({
+    return res.json({
       success: true,
       data: {
         storage: { used: project.storageUsed, limit: project.storageLimit },
@@ -2041,15 +2041,11 @@ module.exports.analytics = async (req, res) => {
         errorRate,
         range,
       },
-      message: "Analytics fetched successfully",
+      message: 'Analytics fetched successfully.',
     });
   } catch (err) {
     console.error('Analytics error:', err);
-    res.status(500).json({
-      success: false,
-      data: {},
-      message: err.message || "Failed to fetch analytics",
-    });
+    return next(new AppError(500, 'Failed to fetch analytics.'));
   }
 };
 // FUNCTION - TOGGLE AUTH

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -1996,37 +1996,44 @@ module.exports.analytics = async (req, res, next) => {
     ]);
 
     // New performance metrics
-    let startDate = new Date();
-    switch (range) {
-      case 'last1h': startDate.setHours(startDate.getHours() - 1); break;
-      case 'last24h': startDate.setDate(startDate.getDate() - 1); break;
-      case 'last7d': startDate.setDate(startDate.getDate() - 7); break;
-      case 'last30d': startDate.setDate(startDate.getDate() - 30); break;
-      default: startDate = new Date(0);
-    }
+    // ✅ Whitelist allowed ranges (including explicit 'allTime')
+const VALID_RANGES = new Set(['last1h', 'last24h', 'last7d', 'last30d', 'allTime']);
+if (!VALID_RANGES.has(range)) {
+  return res.status(400).json({
+    success: false,
+    data: {},
+    message: `Invalid range. Allowed values: ${[...VALID_RANGES].join(', ')}.`,
+  });
+}
+
+let startDate = new Date();
+switch (range) {
+  case 'last1h': startDate.setHours(startDate.getHours() - 1); break;
+  case 'last24h': startDate.setDate(startDate.getDate() - 1); break;
+  case 'last7d': startDate.setDate(startDate.getDate() - 7); break;
+  case 'last30d': startDate.setDate(startDate.getDate() - 30); break;
+  case 'allTime': startDate = new Date(0); break;
+}
 
     const match = {
       projectId: new mongoose.Types.ObjectId(projectId),
       timestamp: { $gte: startDate },
     };
 
-    const latencyAgg = await ApiAnalytics.aggregate([
-      { $match: match },
-      { $group: { _id: null, avg: { $avg: '$responseTimeMs' } } },
-    ]);
-    const avgResponseTimeMs = latencyAgg[0]?.avg ?? null;
-
-    const errorAgg = await ApiAnalytics.aggregate([
-      { $match: match },
-      {
-        $group: {
-          _id: null,
-          total: { $sum: 1 },
-          errors: { $sum: { $cond: [{ $gte: ['$statusCode', 400] }, 1, 0] } },
-        },
-      },
-    ]);
-    const errorRate = errorAgg[0] ? (errorAgg[0].errors / errorAgg[0].total) * 100 : 0;
+   // Single aggregation for both latency and error metrics
+const analyticsAgg = await ApiAnalytics.aggregate([
+  { $match: match },
+  {
+    $group: {
+      _id: null,
+      avg: { $avg: '$responseTimeMs' },
+      total: { $sum: 1 },
+      errors: { $sum: { $cond: [{ $gte: ['$statusCode', 400] }, 1, 0] } },
+    },
+  },
+]);
+const avgResponseTimeMs = analyticsAgg[0]?.avg ?? null;
+const errorRate = analyticsAgg[0] ? (analyticsAgg[0].errors / analyticsAgg[0].total) * 100 : 0;
 
     // ✅ Correct response format
     return res.json({

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -34,6 +34,7 @@ const { verifyUploadedFile } = require("@urbackend/common");
 const { getPublicIp } = require("@urbackend/common");
 const { clearCompiledModel } = require("@urbackend/common");
 const { createUniqueIndexes } = require("@urbackend/common");
+const ApiAnalytics = require('@urbackend/common').ApiAnalytics; // ADDED for analytics
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 const SAFETY_MAX_BYTES = 100 * 1024 * 1024;
@@ -1959,9 +1960,12 @@ module.exports.deleteProject = async (req, res) => {
   }
 };
 
+// MODIFIED analytics function to include API performance metrics
 module.exports.analytics = async (req, res) => {
   try {
     const { projectId } = req.params;
+    const { range = 'last24h' } = req.query; // new query parameter
+
     const project = await Project.findOne({
       _id: projectId,
       owner: req.user._id,
@@ -1970,6 +1974,8 @@ module.exports.analytics = async (req, res) => {
       return res
         .status(404)
         .json({ error: "Project not found or access denied." });
+
+    // --- Existing analytics (storage, database, logs, chartData) ---
     const totalRequests = await Log.countDocuments({ projectId });
     const logs = await Log.find({ projectId })
       .sort({ timestamp: -1 })
@@ -1994,14 +2000,63 @@ module.exports.analytics = async (req, res) => {
       { $sort: { _id: 1 } },
     ]);
 
+    // --- NEW: API performance metrics from ApiAnalytics ---
+    let startDate = new Date();
+    switch (range) {
+      case 'last1h':
+        startDate.setHours(startDate.getHours() - 1);
+        break;
+      case 'last24h':
+        startDate.setDate(startDate.getDate() - 1);
+        break;
+      case 'last7d':
+        startDate.setDate(startDate.getDate() - 7);
+        break;
+      case 'last30d':
+        startDate.setDate(startDate.getDate() - 30);
+        break;
+      default:
+        startDate = new Date(0); // all time
+    }
+
+    const match = {
+      projectId: new mongoose.Types.ObjectId(projectId),
+      timestamp: { $gte: startDate },
+    };
+
+    // Average response time
+    const latencyAgg = await ApiAnalytics.aggregate([
+      { $match: match },
+      { $group: { _id: null, avg: { $avg: '$responseTimeMs' } } },
+    ]);
+    const avgResponseTimeMs = latencyAgg[0]?.avg ?? null;
+
+    // Error rate (status >= 400)
+    const errorAgg = await ApiAnalytics.aggregate([
+      { $match: match },
+      {
+        $group: {
+          _id: null,
+          total: { $sum: 1 },
+          errors: { $sum: { $cond: [{ $gte: ['$statusCode', 400] }, 1, 0] } },
+        },
+      },
+    ]);
+    const errorRate = errorAgg[0] ? (errorAgg[0].errors / errorAgg[0].total) * 100 : 0;
+
+    // --- Response (merge existing + new metrics) ---
     res.json({
       storage: { used: project.storageUsed, limit: project.storageLimit },
       database: { used: project.databaseUsed, limit: project.databaseLimit },
       totalRequests,
       logs,
       chartData,
+      avgResponseTimeMs,   // new
+      errorRate,           // new
+      range,               // optional – echo the requested range
     });
   } catch (err) {
+    console.error('Analytics error:', err);
     res.status(500).json({ error: err.message });
   }
 };

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -33,9 +33,7 @@ const { getPresignedUploadUrl } = require("@urbackend/common");
 const { verifyUploadedFile } = require("@urbackend/common");
 const { getPublicIp } = require("@urbackend/common");
 const { clearCompiledModel } = require("@urbackend/common");
-const { createUniqueIndexes } = require("@urbackend/common");
- // ADDED for analytics
-const ApiAnalytics = require('@urbackend/common').ApiAnalytics;
+const { createUniqueIndexes, ApiAnalytics } = require("@urbackend/common");
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 const SAFETY_MAX_BYTES = 100 * 1024 * 1024;
 const CONFIRM_UPLOAD_SIZE_TOLERANCE_BYTES = 64;

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -1966,10 +1966,7 @@ module.exports.analytics = async (req, res) => {
     const { projectId } = req.params;
     const { range = 'last24h' } = req.query;
 
-    const project = await Project.findOne({
-      _id: projectId,
-      owner: req.user._id,
-    });
+    const project = await Project.findOne({ _id: projectId, owner: req.user._id });
     if (!project) {
       return res.status(404).json({
         success: false,
@@ -1978,15 +1975,12 @@ module.exports.analytics = async (req, res) => {
       });
     }
 
-    // --- Existing analytics ---
+    // Existing analytics
     const totalRequests = await Log.countDocuments({ projectId });
-    const logs = await Log.find({ projectId })
-      .sort({ timestamp: -1 })
-      .limit(50);
+    const logs = await Log.find({ projectId }).sort({ timestamp: -1 }).limit(50);
 
     const sevenDaysAgo = new Date();
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
-
     const chartData = await Log.aggregate([
       {
         $match: {
@@ -2003,23 +1997,14 @@ module.exports.analytics = async (req, res) => {
       { $sort: { _id: 1 } },
     ]);
 
-    // --- NEW: API performance metrics from ApiAnalytics ---
+    // New performance metrics
     let startDate = new Date();
     switch (range) {
-      case 'last1h':
-        startDate.setHours(startDate.getHours() - 1);
-        break;
-      case 'last24h':
-        startDate.setDate(startDate.getDate() - 1);
-        break;
-      case 'last7d':
-        startDate.setDate(startDate.getDate() - 7);
-        break;
-      case 'last30d':
-        startDate.setDate(startDate.getDate() - 30);
-        break;
-      default:
-        startDate = new Date(0); // all time
+      case 'last1h': startDate.setHours(startDate.getHours() - 1); break;
+      case 'last24h': startDate.setDate(startDate.getDate() - 1); break;
+      case 'last7d': startDate.setDate(startDate.getDate() - 7); break;
+      case 'last30d': startDate.setDate(startDate.getDate() - 30); break;
+      default: startDate = new Date(0);
     }
 
     const match = {
@@ -2027,14 +2012,12 @@ module.exports.analytics = async (req, res) => {
       timestamp: { $gte: startDate },
     };
 
-    // Average response time
     const latencyAgg = await ApiAnalytics.aggregate([
       { $match: match },
       { $group: { _id: null, avg: { $avg: '$responseTimeMs' } } },
     ]);
     const avgResponseTimeMs = latencyAgg[0]?.avg ?? null;
 
-    // Error rate (status >= 400)
     const errorAgg = await ApiAnalytics.aggregate([
       { $match: match },
       {
@@ -2047,7 +2030,7 @@ module.exports.analytics = async (req, res) => {
     ]);
     const errorRate = errorAgg[0] ? (errorAgg[0].errors / errorAgg[0].total) * 100 : 0;
 
-    // --- Response with correct format ---
+    // ✅ Correct response format
     res.json({
       success: true,
       data: {
@@ -2071,7 +2054,6 @@ module.exports.analytics = async (req, res) => {
     });
   }
 };
-
 // FUNCTION - TOGGLE AUTH
 module.exports.toggleAuth = async (req, res) => {
   try {

--- a/apps/public-api/src/middlewares/api_usage.js
+++ b/apps/public-api/src/middlewares/api_usage.js
@@ -1,10 +1,9 @@
 const rateLimit = require('express-rate-limit');
 const { Log, redis } = require('@urbackend/common');
 const { getDayKey, DEFAULT_DAILY_TTL_SECONDS, incrWithTtlAtomic } = require('../utils/usageCounter');
-
+const ApiAnalytics = require('@urbackend/common').ApiAnalytics;
 
 // Rate Limiter 
-
 const limiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 100,
@@ -15,17 +14,21 @@ const limiter = rateLimit({
     validate: { trustProxy: false }
 });
 
-// Logger 
+// Logger with API analytics
 const logger = (req, res, next) => {
-    console.time("logger middleware")
+    console.time("logger middleware");
+    
+    // Capture start time for response time measurement
+    const startHr = process.hrtime();
+    
     // Check for Data, Storage, AND UserAuth routes
     if (
         req.originalUrl.startsWith('/api/data') ||
         req.originalUrl.startsWith('/api/storage') ||
         req.originalUrl.startsWith('/api/userAuth')
     ) {
-
         res.on('finish', async () => {
+            // --- Existing logging and usage counter ---
             if (req.project) {
                 try {
                     Log.create({
@@ -37,7 +40,6 @@ const logger = (req, res, next) => {
                     });
 
                     // Usage counter (Redis): daily API requests per project
-                    // Skip increment if usageGate already incremented atomically
                     if (!req._dailyCountIncremented) {
                         const day = getDayKey();
                         const reqCountKey = `project:usage:req:count:${req.project._id}:${day}`;
@@ -49,9 +51,30 @@ const logger = (req, res, next) => {
                     console.error("Logging failed:", e.message);
                 }
             }
+            
+            // --- NEW: API performance analytics ---
+            if (req.project) {
+                const diff = process.hrtime(startHr);
+                const responseTimeMs = (diff[0] * 1e3 + diff[1] / 1e6).toFixed(2);
+                
+                // Asynchronously store analytics
+                setImmediate(async () => {
+                    try {
+                        await ApiAnalytics.create({
+                            projectId: req.project._id,
+                            endpoint: req.route?.path || req.originalUrl,
+                            method: req.method,
+                            statusCode: res.statusCode,
+                            responseTimeMs: parseFloat(responseTimeMs),
+                        });
+                    } catch (err) {
+                        console.error('Failed to save API analytics:', err);
+                    }
+                });
+            }
         });
     }
-    console.timeEnd("logger middleware")
+    console.timeEnd("logger middleware");
     next();
 };
 

--- a/apps/public-api/src/middlewares/api_usage.js
+++ b/apps/public-api/src/middlewares/api_usage.js
@@ -1,7 +1,7 @@
 const rateLimit = require('express-rate-limit');
-const { Log, redis } = require('@urbackend/common');
+const { Log, redis, ApiAnalytics } = require('@urbackend/common');
 const { getDayKey, DEFAULT_DAILY_TTL_SECONDS, incrWithTtlAtomic } = require('../utils/usageCounter');
-const ApiAnalytics = require('@urbackend/common').ApiAnalytics;
+
 
 // Rate Limiter 
 const limiter = rateLimit({

--- a/packages/common/src/models/ApiAnalytics.js
+++ b/packages/common/src/models/ApiAnalytics.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const apiAnalyticsSchema = new mongoose.Schema(
+  {
+    projectId: { type: mongoose.Schema.Types.ObjectId, ref: 'Project', required: true },
+    endpoint: { type: String, required: true },
+    method: { type: String, required: true },
+    statusCode: { type: Number, required: true },
+    responseTimeMs: { type: Number, required: true },
+    timestamp: { type: Date, default: Date.now, index: true },
+  },
+  { timestamps: false }
+);
+
+// TTL index – configurable via environment variable (default: 365 days)
+const ttlDays = parseInt(process.env.ANALYTICS_TTL_DAYS || '365', 10);
+apiAnalyticsSchema.index({ timestamp: 1 }, { expireAfterSeconds: ttlDays * 24 * 60 * 60 });
+
+module.exports = mongoose.model('ApiAnalytics', apiAnalyticsSchema);

--- a/packages/common/src/models/ApiAnalytics.js
+++ b/packages/common/src/models/ApiAnalytics.js
@@ -7,13 +7,18 @@ const apiAnalyticsSchema = new mongoose.Schema(
     method: { type: String, required: true },
     statusCode: { type: Number, required: true },
     responseTimeMs: { type: Number, required: true },
-    timestamp: { type: Date, default: Date.now, index: true },
+    timestamp: { type: Date, default: Date.now }, // TTL index will be applied below
   },
   { timestamps: false }
 );
 
 // TTL index – configurable via environment variable (default: 365 days)
 const ttlDays = parseInt(process.env.ANALYTICS_TTL_DAYS || '365', 10);
-apiAnalyticsSchema.index({ timestamp: 1 }, { expireAfterSeconds: ttlDays * 24 * 60 * 60 });
+if (!isNaN(ttlDays) && ttlDays > 0) {
+  apiAnalyticsSchema.index({ timestamp: 1 }, { expireAfterSeconds: ttlDays * 24 * 60 * 60 });
+} else {
+  console.warn('Invalid ANALYTICS_TTL_DAYS, defaulting to 365 days');
+  apiAnalyticsSchema.index({ timestamp: 1 }, { expireAfterSeconds: 365 * 24 * 60 * 60 });
+}
 
 module.exports = mongoose.model('ApiAnalytics', apiAnalyticsSchema);

--- a/packages/common/src/models/index.js
+++ b/packages/common/src/models/index.js
@@ -1,0 +1,1 @@
+module.exports.ApiAnalytics = require('./ApiAnalytics');


### PR DESCRIPTION
Closes #138

## Summary
- Added `ApiAnalytics` model with TTL index (configurable via `ANALYTICS_TTL_DAYS`).
- Extended `api_usage.js` middleware to log response time (`process.hrtime`) and status code asynchronously.
- Extended existing `GET /api/projects/:projectId/analytics` endpoint with `avgResponseTimeMs` and `errorRate`.

## Testing
- Verified that analytics documents are created on API calls (using manual requests).
- Verified that the analytics endpoint returns the new metrics for different time ranges.
- Existing functionality (logs, rate limiting) remains intact.

## Note
Local MongoDB is a standalone instance (transactions not supported), causing unrelated 500 errors on project creation. This PR does not modify any transaction code and is safe to merge. The maintainer’s CI/replica set environment will confirm the changes work as expected.

## Related
- Issue #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analytics endpoint accepts a time-range parameter (defaults to last 24 hours).
  * New performance metrics: average response time and error rate across the selected period.
  * API now records performance analytics for requests in the background to populate charts and summaries.
* **Other**
  * Analytics responses use a standardized success/data/message wrapper and echo the selected range.
* **Chores**
  * Analytics storage includes a configurable retention policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->