### PR TITLE
feat(collections): add optional field default values across schema, v…

### DIFF
--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -99,6 +99,9 @@ const sanitizeSchemaFields = (schema = []) => {
       if (!normalizedKey) return null;
 
       const next = { ...field, key: normalizedKey };
+      if (field.default !== undefined) {
+        next.default = field.default;
+      }
 
       if (Array.isArray(field.fields)) {
         next.fields = sanitizeSchemaFields(field.fields);

--- a/apps/public-api/src/__tests__/data.defaults.test.js
+++ b/apps/public-api/src/__tests__/data.defaults.test.js
@@ -1,0 +1,50 @@
+const {
+  validateData,
+  validateUpdateData,
+} = require('../../../../packages/common/src/utils/validateData');
+
+describe('default values behavior for collection fields', () => {
+  const schemaRules = [
+    { key: 'title', type: 'String', required: true },
+    { key: 'status', type: 'String', required: false, default: 'pending' },
+  ];
+
+  test('insert without optional field applies default', () => {
+    const { error, cleanData } = validateData({ title: 'Order A' }, schemaRules);
+
+    expect(error).toBeUndefined();
+    expect(cleanData).toEqual(
+      expect.objectContaining({
+        title: 'Order A',
+        status: 'pending',
+      }),
+    );
+  });
+
+  test('insert with explicit field value does not override with default', () => {
+    const { error, cleanData } = validateData(
+      { title: 'Order B', status: 'confirmed' },
+      schemaRules,
+    );
+
+    expect(error).toBeUndefined();
+    expect(cleanData).toEqual(
+      expect.objectContaining({
+        title: 'Order B',
+        status: 'confirmed',
+      }),
+    );
+  });
+
+  test('update payload does not inject defaults for missing fields', () => {
+    const { error, updateData } = validateUpdateData({ title: 'Order C' }, schemaRules);
+
+    expect(error).toBeUndefined();
+    expect(updateData).toEqual(
+      expect.objectContaining({
+        title: 'Order C',
+      }),
+    );
+    expect(Object.prototype.hasOwnProperty.call(updateData, 'status')).toBe(false);
+  });
+});

--- a/apps/web-dashboard/src/pages/CreateCollection.jsx
+++ b/apps/web-dashboard/src/pages/CreateCollection.jsx
@@ -17,7 +17,7 @@ const ALL_TYPES = [...PRIMITIVE_TYPES, 'Object', 'Array', 'Ref'];
 const ARRAY_ITEM_TYPES = [...PRIMITIVE_TYPES, 'Object', 'Ref'];
 
 function createEmptyField() {
-    return { _id: nextFieldId(), key: '', type: 'String', required: false, unique: false };
+    return { _id: nextFieldId(), key: '', type: 'String', required: false, unique: false, default: undefined };
 }
 
 // FUNCTION - FIELD ROW COMPONENT
@@ -33,6 +33,7 @@ function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
             delete updated.fields;
             delete updated.items;
             delete updated.ref;
+            delete updated.default;
             if (value === 'Object') {
                 updated.fields = [createEmptyField()];
                 updated.unique = false;
@@ -44,6 +45,11 @@ function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
                 updated.unique = false;
             }
         }
+
+        if (prop === 'required' && value) {
+            delete updated.default;
+        }
+        
         onChange(index, updated);
     };
 
@@ -51,6 +57,32 @@ function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
         const newFields = [...(field.fields || [])];
         newFields[subIndex] = updatedSubField;
         onChange(index, { ...field, fields: newFields });
+    };
+
+    const handleDefaultChange = (rawValue) => {
+      if (field.locked) return;
+    
+      let nextDefault;
+      if (field.type === 'String') {
+        nextDefault = rawValue === '' ? undefined : rawValue;
+      } else if (field.type === 'Number') {
+        if (rawValue === '') nextDefault = undefined;
+        else {
+          const parsed = Number(rawValue);
+          nextDefault = Number.isNaN(parsed) ? undefined : parsed;
+        }
+      } else if (field.type === 'Boolean') {
+        if (rawValue === '') nextDefault = undefined;
+        else nextDefault = rawValue === 'true';
+      } else {
+        nextDefault = undefined;
+      }
+    
+      const updated = { ...field };
+      if (nextDefault === undefined) delete updated.default;
+      else updated.default = nextDefault;
+    
+      onChange(index, updated);
     };
 
     const addSubField = () => {
@@ -211,6 +243,38 @@ function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
                 </button>
             </div>
 
+            {!field.required && ['String', 'Number', 'Boolean'].includes(field.type) && (
+              <div style={{ marginLeft: '26px', marginBottom: '8px', display: 'flex', gap: '8px', alignItems: 'center' }}>
+                <span style={{ fontSize: '0.8rem', color: 'var(--color-text-muted)', whiteSpace: 'nowrap' }}>
+                  → Default Value:
+                </span>
+
+                {field.type === 'Boolean' ? (
+                  <select
+                    value={field.default === true ? 'true' : field.default === false ? 'false' : ''}
+                    disabled={field.locked}
+                    onChange={(e) => handleDefaultChange(e.target.value)}
+                    className="input-field"
+                    style={{ flex: 1, fontSize: '0.85rem', padding: '4px 8px', background: 'rgba(0,0,0,0.2)', border: '1px solid var(--color-border)', borderRadius: '4px' }}
+                  >
+                    <option value="">No default</option>
+                    <option value="true">true</option>
+                    <option value="false">false</option>
+                  </select>
+                ) : (
+                  <input
+                    type={field.type === 'Number' ? 'number' : 'text'}
+                    value={field.default ?? ''}
+                    disabled={field.locked}
+                    onChange={(e) => handleDefaultChange(e.target.value)}
+                    className="input-field"
+                    placeholder={field.type === 'Number' ? 'e.g. 0' : 'e.g. pending'}
+                    style={{ flex: 1, fontSize: '0.85rem', padding: '4px 8px', background: 'rgba(0,0,0,0.2)', border: '1px solid var(--color-border)', borderRadius: '4px' }}
+                  />
+                )}
+              </div>
+            )}
+
             {/* Ref — Collection Picker */}
             {field.type === 'Ref' && (
                 <div style={{ marginLeft: '26px', marginBottom: '8px', display: 'flex', gap: '8px', alignItems: 'center' }}>
@@ -312,7 +376,6 @@ function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
                                 ))}
                             </div>
                         )}
-
                         {/* Array of Ref — collection picker */}
                         {field.items?.type === 'Ref' && (
                             <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginTop: '4px' }}>
@@ -342,7 +405,13 @@ function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
 // FUNCTION - CLEAN FIELDS FOR API
 function cleanFieldsForApi(fields) {
     return fields.map(f => {
-        const { _id, ...clean } = f;
+      const { _id, ...clean } = f;
+      
+      const supportsDefault = ['String', 'Number', 'Boolean'].includes(clean.type);
+      if (clean.required || !supportsDefault || clean.default === undefined) {
+        delete clean.default;
+      }
+      
         if (clean.fields) clean.fields = cleanFieldsForApi(clean.fields);
         if (clean.items?.fields) {
             clean.items = { ...clean.items, fields: cleanFieldsForApi(clean.items.fields) };

--- a/packages/common/src/models/Project.js
+++ b/packages/common/src/models/Project.js
@@ -23,6 +23,8 @@ const fieldSchema = new mongoose.Schema({
   ref: { type: String },
   // For type: 'Array' — describes each array item { type, fields? }
   items: { type: mongoose.Schema.Types.Mixed },
+
+  default: { type: mongoose.Schema.Types.Mixed, default: undefined },
 });
 
 // For type: 'Object' — recursive sub-fields

--- a/packages/common/src/utils/injectModel.js
+++ b/packages/common/src/utils/injectModel.js
@@ -77,6 +77,11 @@ function buildFieldDef(field, projectId, isExternal, isUsersCollection = false) 
     required: !!field.required,
   };
 
+  // pass default through when defined
+  if (field.default !== undefined) {
+    def.default = field.default;
+  }
+
   // HARDEN: Exclude password by default for project users
   if (isUsersCollection && normalizeKey(field.key) === "password") {
     def.select = false;

--- a/packages/common/src/utils/input.validation.js
+++ b/packages/common/src/utils/input.validation.js
@@ -163,17 +163,25 @@ const buildFieldSchemaZod = (depth = 1) => {
     )
     .refine(
       (field) => {
-        if (field.required === true && field.default !== undefined) return false;
+        // Reject defaults on required fields
+        if (field.required === true && field.default !== undefined)
+          return false;
+        // Reject defaults for unsupported types
         if (field.default === undefined) return true;
-        if (field.required === true) return false;
-        if (field.type === "String") return typeof field.default === "string";
-        if (field.type === "Number") return typeof field.default === "number";
-        if (field.type === "Boolean") return typeof field.default === "boolean";
-        return false; // Disallow defaults for Object, Array, Ref, Date
+        const unsupported = ["Date", "Object", "Array", "Ref"];
+        if (unsupported.includes(field.type)) return false;
+        // Type-match check
+        if (field.type === "String" && typeof field.default !== "string")
+          return false;
+        if (field.type === "Number" && typeof field.default !== "number")
+          return false;
+        if (field.type === "Boolean" && typeof field.default !== "boolean")
+          return false;
+        return true;
       },
       {
         message:
-          "Default value type must match field type and cannot be set on required fields",
+          "Default value type must match field type, and required fields cannot have defaults",
       },
     );
 
@@ -282,23 +290,33 @@ const buildApiFieldSchemaZod = (depth = 1) => {
           "Invalid field configuration, nesting depth exceeded (max 3 levels), or unique is only supported for top-level primitive fields.",
       },
     )
-    .refine( 
+    .refine(
       (field) => {
+        // Reject defaults on required fields
+        if (field.required === true && field.default !== undefined)
+          return false;
+        // Reject defaults for unsupported types
         if (field.default === undefined) return true;
-        if (field.required === true) return false;
 
         const normalType =
           field.type.charAt(0).toUpperCase() +
           field.type.slice(1).toLowerCase();
 
-        if (normalType === "String") return typeof field.default === "string";
-        if (normalType === "Number") return typeof field.default === "number";
-        if (normalType === "Boolean") return typeof field.default === "boolean";
-        return false; // Disallow defaults for Object, Array, Ref, Date
+        const unsupported = ["Date", "Object", "Array", "Ref"];
+        if (unsupported.includes(normalType)) return false;
+
+        // Type-match check
+        if (normalType === "String" && typeof field.default !== "string")
+          return false;
+        if (normalType === "Number" && typeof field.default !== "number")
+          return false;
+        if (normalType === "Boolean" && typeof field.default !== "boolean")
+          return false;
+        return true;
       },
       {
         message:
-          "Default value type must match field type and cannot be set on required fields",
+          "Default value type must match field type, and required fields cannot have defaults",
       },
     );
 

--- a/packages/common/src/utils/input.validation.js
+++ b/packages/common/src/utils/input.validation.js
@@ -164,12 +164,16 @@ const buildFieldSchemaZod = (depth = 1) => {
     .refine(
       (field) => {
         if (field.default === undefined) return true;
+        if (field.required === true) return false;
         if (field.type === "String") return typeof field.default === "string";
         if (field.type === "Number") return typeof field.default === "number";
         if (field.type === "Boolean") return typeof field.default === "boolean";
         return false; // Disallow defaults for Object, Array, Ref, Date
       },
-      { message: "Default value type must match field type" },
+      {
+        message:
+          "Default value type must match field type and cannot be set on required fields",
+      },
     );
 
   return base;
@@ -280,6 +284,7 @@ const buildApiFieldSchemaZod = (depth = 1) => {
     .refine( 
       (field) => {
         if (field.default === undefined) return true;
+        if (field.required === true) return false;
 
         const normalType =
           field.type.charAt(0).toUpperCase() +
@@ -290,7 +295,10 @@ const buildApiFieldSchemaZod = (depth = 1) => {
         if (normalType === "Boolean") return typeof field.default === "boolean";
         return false; // Disallow defaults for Object, Array, Ref, Date
       },
-      { message: "Default value type must match field type" },
+      {
+        message:
+          "Default value type must match field type and cannot be set on required fields",
+      },
     );
 
   return base;

--- a/packages/common/src/utils/input.validation.js
+++ b/packages/common/src/utils/input.validation.js
@@ -110,6 +110,7 @@ const buildFieldSchemaZod = (depth = 1) => {
       ]),
       required: z.boolean().optional(),
       unique: z.boolean().optional(),
+      default: z.any().optional(),
       ref: z.string().optional(),
       items: z
         .object({
@@ -159,6 +160,16 @@ const buildFieldSchemaZod = (depth = 1) => {
         message:
           "Invalid field configuration, nesting depth exceeded (max 3 levels), or unique is only supported for top-level primitive fields.",
       },
+    )
+    .refine(
+      (field) => {
+        if (field.default === undefined) return true;
+        if (field.type === "String") return typeof field.default === "string";
+        if (field.type === "Number") return typeof field.default === "number";
+        if (field.type === "Boolean") return typeof field.default === "boolean";
+        return false; // Disallow defaults for Object, Array, Ref, Date
+      },
+      { message: "Default value type must match field type" },
     );
 
   return base;
@@ -202,6 +213,7 @@ const buildApiFieldSchemaZod = (depth = 1) => {
       ]),
       required: z.boolean().optional(),
       unique: z.boolean().optional(),
+      default: z.any().optional(),
       ref: z.string().optional(),
       items: z
         .object({
@@ -264,6 +276,21 @@ const buildApiFieldSchemaZod = (depth = 1) => {
         message:
           "Invalid field configuration, nesting depth exceeded (max 3 levels), or unique is only supported for top-level primitive fields.",
       },
+    )
+    .refine( 
+      (field) => {
+        if (field.default === undefined) return true;
+
+        const normalType =
+          field.type.charAt(0).toUpperCase() +
+          field.type.slice(1).toLowerCase();
+
+        if (normalType === "String") return typeof field.default === "string";
+        if (normalType === "Number") return typeof field.default === "number";
+        if (normalType === "Boolean") return typeof field.default === "boolean";
+        return false; // Disallow defaults for Object, Array, Ref, Date
+      },
+      { message: "Default value type must match field type" },
     );
 
   return base;

--- a/packages/common/src/utils/input.validation.js
+++ b/packages/common/src/utils/input.validation.js
@@ -163,6 +163,7 @@ const buildFieldSchemaZod = (depth = 1) => {
     )
     .refine(
       (field) => {
+        if (field.required === true && field.default !== undefined) return false;
         if (field.default === undefined) return true;
         if (field.required === true) return false;
         if (field.type === "String") return typeof field.default === "string";

--- a/packages/common/src/utils/validateData.js
+++ b/packages/common/src/utils/validateData.js
@@ -122,6 +122,14 @@ function validateData(incomingData, schemaRules) {
             ? normalizedValueMap.get(fieldKey)
             : incomingData[field.key];
 
+      if (
+        (value === undefined || value === null) &&
+        !field.required &&
+        field.default !== undefined
+        ) {
+          value = field.default;
+        }
+      
         // ✅ FIX: trim BEFORE validation and storage
         if (field.type === 'String' && typeof value === 'string') {
             value = value.trim();


### PR DESCRIPTION
Fixes #147

This PR adds support for **optional default values** in collection field schemas across model, validation, runtime behavior, dashboard API sanitization, and Create Collection UI.

### What’s included

- Added `default` field to collection `fieldSchema` in `packages/common/src/models/Project.js`:
  - `default: { type: mongoose.Schema.Types.Mixed, default: undefined }`

- Extended schema validation in `packages/common/src/utils/input.validation.js`:
  - `default` allowed as optional field input
  - Type-aware validation for defaults:
    - `String` -> string
    - `Number` -> number
    - `Boolean` -> boolean
  - Rejects defaults for unsupported types (`Date`, `Object`, `Array`, `Ref`)
  - Applied to both dashboard create schema flow and API schema-key flow

- Updated schema compiler in `packages/common/src/utils/injectModel.js`:
  - `buildFieldDef()` now forwards `default` into Mongoose field definitions when present

- Updated insert validation behavior in `packages/common/src/utils/validateData.js`:
  - `validateData()` injects default for missing optional fields
  - `validateUpdateData()` remains unchanged (no default injection on updates)

- Updated dashboard API sanitization in `apps/dashboard-api/src/controllers/project.controller.js`:
  - `sanitizeSchemaFields()` preserves `default` while normalizing fields

- Updated dashboard Create Collection UI in `apps/web-dashboard/src/pages/CreateCollection.jsx`:
  - Added **Default Value** input per field
  - Visible only when `required === false`
  - Type-aware input behavior:
    - String text input
    - Number numeric input
    - Boolean select (`No default` / `true` / `false`)
  - Payload sanitization ensures defaults only sent for supported optional primitive fields

- Added regression tests in `apps/public-api/src/__tests__/data.defaults.test.js`:
  - insert without field -> default applied
  - insert with explicit field -> default not overridden
  - update payload -> default not injected

---

## 🛠️ Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🎨 UI/UX improvement (Frontend only)

## 🧪 Testing & Validation
### Backend Verification:
- [x] I have run `npx jest` in the `backend/` directory and all tests passed.
- [x] New unit tests have been added (if applicable).

### Frontend Verification:
- [x] I have run `npm run lint` in the `frontend/` directory.
- [x] Verified the UI changes on different screen sizes (Responsive).
- [x] Checked for any console errors in the browser dev tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection fields can include configurable defaults for non-required primitive types; defaults are applied when creating records and a UI editor lets you set them.
* **Improvements**
  * Validation prevents combining required+default and ensures default types match field types; defaults are omitted where inappropriate (required, unsupported types, or undefined).
* **Tests**
  * Added tests covering default injection on create, preservation of explicit values, and absence of defaults on updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->