### PR TITLE
fix: reduce loading latency on create-collection page

### DIFF
--- a/apps/web-dashboard/src/pages/CreateCollection.jsx
+++ b/apps/web-dashboard/src/pages/CreateCollection.jsx
@@ -21,7 +21,7 @@ function createEmptyField() {
 }
 
 // FUNCTION - FIELD ROW COMPONENT
-function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
+function FieldRow({ field, index, depth, collections, collectionsLoading, onChange, onRemove }) {
     const [expanded, setExpanded] = useState(true);
 
     const handleChange = (prop, value) => {
@@ -283,11 +283,12 @@ function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
                     </span>
                     <select
                         value={field.ref || ''}
+                        disabled={collectionsLoading}
                         onChange={(e) => handleChange('ref', e.target.value)}
                         className="input-field"
                         style={{ flex: 1, fontSize: '0.85rem', padding: '4px 8px', background: 'rgba(0,0,0,0.2)', border: '1px solid var(--color-border)', borderRadius: '4px' }}
                     >
-                        <option value="">Select collection...</option>
+                        <option value="">{collectionsLoading ? 'Loading collections…' : 'Select collection...'}</option>
                         {collections.map(c => (
                             <option key={c.name} value={c.name}>{c.name}</option>
                         ))}
@@ -320,6 +321,7 @@ function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
                                 index={subIdx}
                                 depth={depth + 1}
                                 collections={collections}
+                                collectionsLoading={collectionsLoading}
                                 onChange={handleSubFieldChange}
                                 onRemove={removeSubField}
                             />
@@ -370,6 +372,7 @@ function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
                                         index={subIdx}
                                         depth={depth + 1}
                                         collections={collections}
+                                        collectionsLoading={collectionsLoading}
                                         onChange={handleItemSubFieldChange}
                                         onRemove={removeItemSubField}
                                     />
@@ -384,11 +387,12 @@ function FieldRow({ field, index, depth, collections, onChange, onRemove }) {
                                 </span>
                                 <select
                                     value={field.items?.ref || ''}
+                                    disabled={collectionsLoading}
                                     onChange={(e) => handleItemsChange('ref', e.target.value)}
                                     className="input-field"
                                     style={{ flex: 1, fontSize: '0.85rem', padding: '4px 8px', background: 'rgba(0,0,0,0.2)', border: '1px solid var(--color-border)', borderRadius: '4px' }}
                                 >
-                                    <option value="">Select collection...</option>
+                                    <option value="">{collectionsLoading ? 'Loading collections…' : 'Select collection...'}</option>
                                     {collections.map(c => (
                                         <option key={c.name} value={c.name}>{c.name}</option>
                                     ))}
@@ -454,15 +458,19 @@ function CreateCollection() {
     const [fields, setFields] = useState(getInitialFields());
     const [loading, setLoading] = useState(false);
     const [collections, setCollections] = useState([]);
+    const [collectionsLoading, setCollectionsLoading] = useState(true);
 
-    // Fetch existing collections for Ref picker
+    // Fetch existing collections for Ref picker — runs immediately on mount
+    // so it fires in parallel with any other in-flight requests.
     useEffect(() => {
         let isMounted = true;
         const fetchCollections = async () => {
             try {
                 const res = await api.get(`/api/projects/${projectId}`);
                 if (isMounted) setCollections(res.data.collections || []);
-            } catch { /* ignore */ }
+            } catch { /* ignore */ } finally {
+                if (isMounted) setCollectionsLoading(false);
+            }
         };
         fetchCollections();
         return () => { isMounted = false; };
@@ -598,6 +606,7 @@ function CreateCollection() {
                                 index={index}
                                 depth={1}
                                 collections={collections}
+                                collectionsLoading={collectionsLoading}
                                 onChange={handleFieldChange}
                                 onRemove={removeField}
                             />

--- a/apps/web-dashboard/src/pages/CreateCollection.jsx
+++ b/apps/web-dashboard/src/pages/CreateCollection.jsx
@@ -21,7 +21,7 @@ function createEmptyField() {
 }
 
 // FUNCTION - FIELD ROW COMPONENT
-function FieldRow({ field, index, depth, collections, collectionsLoading, onChange, onRemove }) {
+function FieldRow({ field, index, depth, collections, collectionsLoading, collectionsError, onChange, onRemove }) {
     const [expanded, setExpanded] = useState(true);
 
     const handleChange = (prop, value) => {
@@ -283,12 +283,12 @@ function FieldRow({ field, index, depth, collections, collectionsLoading, onChan
                     </span>
                     <select
                         value={field.ref || ''}
-                        disabled={collectionsLoading}
+                        disabled={collectionsLoading || collectionsError}
                         onChange={(e) => handleChange('ref', e.target.value)}
                         className="input-field"
                         style={{ flex: 1, fontSize: '0.85rem', padding: '4px 8px', background: 'rgba(0,0,0,0.2)', border: '1px solid var(--color-border)', borderRadius: '4px' }}
                     >
-                        <option value="">{collectionsLoading ? 'Loading collections…' : 'Select collection...'}</option>
+                        <option value="">{collectionsLoading ? 'Loading collections…' : collectionsError ? 'Failed to load' : 'Select collection...'}</option>
                         {collections.map(c => (
                             <option key={c.name} value={c.name}>{c.name}</option>
                         ))}
@@ -322,6 +322,7 @@ function FieldRow({ field, index, depth, collections, collectionsLoading, onChan
                                 depth={depth + 1}
                                 collections={collections}
                                 collectionsLoading={collectionsLoading}
+                                collectionsError={collectionsError}
                                 onChange={handleSubFieldChange}
                                 onRemove={removeSubField}
                             />
@@ -373,6 +374,7 @@ function FieldRow({ field, index, depth, collections, collectionsLoading, onChan
                                         depth={depth + 1}
                                         collections={collections}
                                         collectionsLoading={collectionsLoading}
+                                        collectionsError={collectionsError}
                                         onChange={handleItemSubFieldChange}
                                         onRemove={removeItemSubField}
                                     />
@@ -387,12 +389,12 @@ function FieldRow({ field, index, depth, collections, collectionsLoading, onChan
                                 </span>
                                 <select
                                     value={field.items?.ref || ''}
-                                    disabled={collectionsLoading}
+                                    disabled={collectionsLoading || collectionsError}
                                     onChange={(e) => handleItemsChange('ref', e.target.value)}
                                     className="input-field"
                                     style={{ flex: 1, fontSize: '0.85rem', padding: '4px 8px', background: 'rgba(0,0,0,0.2)', border: '1px solid var(--color-border)', borderRadius: '4px' }}
                                 >
-                                    <option value="">{collectionsLoading ? 'Loading collections…' : 'Select collection...'}</option>
+                                    <option value="">{collectionsLoading ? 'Loading collections…' : collectionsError ? 'Failed to load' : 'Select collection...'}</option>
                                     {collections.map(c => (
                                         <option key={c.name} value={c.name}>{c.name}</option>
                                     ))}
@@ -459,6 +461,7 @@ function CreateCollection() {
     const [loading, setLoading] = useState(false);
     const [collections, setCollections] = useState([]);
     const [collectionsLoading, setCollectionsLoading] = useState(true);
+    const [collectionsError, setCollectionsError] = useState(null);
 
     // Fetch existing collections for Ref picker — runs immediately on mount
     // so it fires in parallel with any other in-flight requests.
@@ -468,11 +471,18 @@ function CreateCollection() {
             if (isMounted) {
                 setCollectionsLoading(true);
                 setCollections([]);
+                setCollectionsError(null);
             }
             try {
                 const res = await api.get(`/api/projects/${projectId}`);
                 if (isMounted) setCollections(res.data.collections || []);
-            } catch { /* ignore */ } finally {
+            } catch (err) {
+                console.error('Failed to fetch collections for Ref picker:', err);
+                if (isMounted) {
+                    setCollectionsError('Failed to load collections');
+                    toast.error('Failed to load collections for references');
+                }
+            } finally {
                 if (isMounted) setCollectionsLoading(false);
             }
         };
@@ -611,6 +621,7 @@ function CreateCollection() {
                                 depth={1}
                                 collections={collections}
                                 collectionsLoading={collectionsLoading}
+                                collectionsError={collectionsError}
                                 onChange={handleFieldChange}
                                 onRemove={removeField}
                             />

--- a/apps/web-dashboard/src/pages/CreateCollection.jsx
+++ b/apps/web-dashboard/src/pages/CreateCollection.jsx
@@ -465,6 +465,10 @@ function CreateCollection() {
     useEffect(() => {
         let isMounted = true;
         const fetchCollections = async () => {
+            if (isMounted) {
+                setCollectionsLoading(true);
+                setCollections([]);
+            }
             try {
                 const res = await api.get(`/api/projects/${projectId}`);
                 if (isMounted) setCollections(res.data.collections || []);

--- a/apps/web-dashboard/src/utils/api.js
+++ b/apps/web-dashboard/src/utils/api.js
@@ -7,6 +7,9 @@ const api = axios.create({
 });
 
 let csrfToken = null;
+// Eagerly start fetching the CSRF token as soon as this module loads so the
+// token is already available by the time the user submits any form.
+let csrfTokenPromise = null;
 
 const fetchCsrfToken = async () => {
     try {
@@ -19,12 +22,16 @@ const fetchCsrfToken = async () => {
     }
 };
 
+// Kick off the fetch immediately — reuse the same promise to avoid duplicate requests.
+csrfTokenPromise = fetchCsrfToken();
+
 api.interceptors.request.use(async (config) => {
     const method = config.method.toLowerCase();
     
     if (['post', 'put', 'delete', 'patch'].includes(method)) {
         if (!csrfToken) {
-            csrfToken = await fetchCsrfToken();
+            // Wait for the in-flight eager fetch instead of spawning a new one.
+            csrfToken = await (csrfTokenPromise ?? fetchCsrfToken());
         }
         if (csrfToken) {
             config.headers['X-CSRF-Token'] = csrfToken;

--- a/apps/web-dashboard/src/utils/api.js
+++ b/apps/web-dashboard/src/utils/api.js
@@ -18,6 +18,8 @@ const fetchCsrfToken = async () => {
         return csrfToken;
     } catch (err) {
         console.error("Failed to fetch CSRF token:", err);
+        // Clear the promise so subsequent requests will retry instead of reusing a failed result.
+        csrfTokenPromise = null;
         return null;
     }
 };
@@ -26,12 +28,16 @@ const fetchCsrfToken = async () => {
 csrfTokenPromise = fetchCsrfToken();
 
 api.interceptors.request.use(async (config) => {
-    const method = config.method.toLowerCase();
+    // Guard against undefined method (defaults to 'get')
+    const method = (config.method || 'get').toLowerCase();
     
     if (['post', 'put', 'delete', 'patch'].includes(method)) {
         if (!csrfToken) {
-            // Wait for the in-flight eager fetch instead of spawning a new one.
-            csrfToken = await (csrfTokenPromise ?? fetchCsrfToken());
+            // If the eager fetch failed (csrfTokenPromise is null), trigger a fresh fetch.
+            if (!csrfTokenPromise) {
+                csrfTokenPromise = fetchCsrfToken();
+            }
+            csrfToken = await csrfTokenPromise;
         }
         if (csrfToken) {
             config.headers['X-CSRF-Token'] = csrfToken;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,7 @@
         "sdks/*"
       ],
       "dependencies": {
-        "axios": "^1.16.0",
-        "lucide-react": "^1.14.0",
-        "path": "^0.12.7",
-        "react": "^19.2.5",
-        "react-hot-toast": "^2.6.0",
-        "react-router-dom": "^7.15.0"
+        "path": "^0.12.7"
       },
       "devDependencies": {
         "concurrently": "^9.2.1"
@@ -9893,15 +9888,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
-      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/luxon": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,12 @@
         "sdks/*"
       ],
       "dependencies": {
-        "path": "^0.12.7"
+        "axios": "^1.16.0",
+        "lucide-react": "^1.14.0",
+        "path": "^0.12.7",
+        "react": "^19.2.5",
+        "react-hot-toast": "^2.6.0",
+        "react-router-dom": "^7.15.0"
       },
       "devDependencies": {
         "concurrently": "^9.2.1"
@@ -109,6 +114,15 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "vite": "8.0.10"
+      }
+    },
+    "apps/web-dashboard/node_modules/lucide-react": {
+      "version": "0.554.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.554.0.tgz",
+      "integrity": "sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -5755,12 +5769,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -9882,9 +9896,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.554.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.554.0.tgz",
-      "integrity": "sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+      "integrity": "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -12106,9 +12120,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -12128,12 +12142,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
-      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.2"
+        "react-router": "7.15.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
     "concurrently": "^9.2.1"
   },
   "dependencies": {
-    "path": "^0.12.7"
+    "axios": "^1.16.0",
+    "lucide-react": "^1.14.0",
+    "path": "^0.12.7",
+    "react": "^19.2.5",
+    "react-hot-toast": "^2.6.0",
+    "react-router-dom": "^7.15.0"
   },
   "overrides": {
     "rollup": "npm:@rollup/wasm-node"

--- a/package.json
+++ b/package.json
@@ -17,12 +17,7 @@
     "concurrently": "^9.2.1"
   },
   "dependencies": {
-    "axios": "^1.16.0",
-    "lucide-react": "^1.14.0",
-    "path": "^0.12.7",
-    "react": "^19.2.5",
-    "react-hot-toast": "^2.6.0",
-    "react-router-dom": "^7.15.0"
+    "path": "^0.12.7"
   },
   "overrides": {
     "rollup": "npm:@rollup/wasm-node"


### PR DESCRIPTION
## Problem
The `/create-collection` page was slow to appear for two compounding reasons:

1. **CSRF token lazy-fetch added a hidden round-trip on first submit** — `csrfToken` started as `null`, so the request interceptor in `api.js` fired a blocking `GET /api/auth/csrf-token` before every first mutating request.
2. **No loading state on the Ref-picker collections fetch** — the `useEffect` in `CreateCollection` fetched project collections silently, leaving Ref dropdown in an empty/broken state until the request completed with no user feedback.

## Changes

### `src/utils/api.js`
- **Eagerly prefetch the CSRF token** when the module loads by starting `fetchCsrfToken()` immediately and storing the `Promise`.
- The request interceptor now awaits the in-flight promise instead of spawning a new fetch, eliminating the extra round-trip on first form submit.

### `src/pages/CreateCollection.jsx`
- Added `collectionsLoading` state that starts `true` and becomes `false` when the project fetch resolves.
- Both `Ref` picker `<select>` elements (direct field refs and array item refs) are now `disabled` while loading and show `"Loading collections…"` as the placeholder option.
- `collectionsLoading` is threaded through all recursive `FieldRow` renders so nested pickers also reflect the loading state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Collection pickers now show explicit loading and error states ("Loading collections…", "Failed to load"), disable selection while unavailable, and apply this behavior to nested/ref fields.
  * Request handling improved to eagerly obtain CSRF tokens and better coordinate token fetching for mutating requests, improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->