### PR TITLE
fix: add OTP cooldown/rate-limiting to requestPasswordReset endpoint

### DIFF
--- a/apps/public-api/src/__tests__/userAuth.email.test.js
+++ b/apps/public-api/src/__tests__/userAuth.email.test.js
@@ -368,6 +368,7 @@ describe('Email Authentication Flow', () => {
             const res = makeRes();
 
             mockModel.findOne.mockResolvedValueOnce({ _id: 'user_123' });
+            redis.get.mockResolvedValueOnce(null); // no cooldown
 
             await controller.requestPasswordReset(req, res);
 
@@ -376,6 +377,51 @@ describe('Email Authentication Flow', () => {
                 email: 'reset@user.com'
             }));
             expect(res.json).toHaveBeenCalled();
+        });
+
+        test('returns 429 when reset OTP cooldown is active', async () => {
+            const req = makeReq({ body: { email: 'reset@user.com' } });
+            const res = makeRes();
+
+            mockModel.findOne.mockResolvedValueOnce({ _id: 'user_123' });
+            redis.get.mockResolvedValueOnce('1'); // cooldown active
+            redis.ttl.mockResolvedValueOnce(45);
+
+            await controller.requestPasswordReset(req, res);
+
+            expect(authEmailQueue.add).not.toHaveBeenCalled();
+            expect(res.status).toHaveBeenCalledWith(429);
+            expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+                error: expect.stringContaining('45 seconds')
+            }));
+        });
+
+        test('sets cooldown after sending reset OTP', async () => {
+            const req = makeReq({ body: { email: 'reset@user.com' } });
+            const res = makeRes();
+
+            mockModel.findOne.mockResolvedValueOnce({ _id: 'user_123' });
+            redis.get.mockResolvedValueOnce(null);
+
+            await controller.requestPasswordReset(req, res);
+
+            const cooldownCall = redis.set.mock.calls.find(c => c[0].includes('otp:cooldown:reset'));
+            expect(cooldownCall).toBeDefined();
+            expect(cooldownCall[2]).toBe('EX');
+            expect(cooldownCall[3]).toBe(60);
+        });
+
+        test('uses normalized email in Redis key', async () => {
+            const req = makeReq({ body: { email: 'Reset@User.COM' } });
+            const res = makeRes();
+
+            mockModel.findOne.mockResolvedValueOnce({ _id: 'user_123' });
+            redis.get.mockResolvedValueOnce(null);
+
+            await controller.requestPasswordReset(req, res);
+
+            const otpCall = redis.set.mock.calls.find(c => c[0].includes('otp:reset'));
+            expect(otpCall[0]).toContain('reset@user.com');
         });
     });
 

--- a/apps/public-api/src/__tests__/userAuth.email.test.js
+++ b/apps/public-api/src/__tests__/userAuth.email.test.js
@@ -379,22 +379,37 @@ describe('Email Authentication Flow', () => {
             expect(res.json).toHaveBeenCalled();
         });
 
-        test('returns 429 when reset OTP cooldown is active', async () => {
+        test('returns 429 when reset OTP cooldown is active (before DB lookup)', async () => {
             const req = makeReq({ body: { email: 'reset@user.com' } });
             const res = makeRes();
 
-            mockModel.findOne.mockResolvedValueOnce({ _id: 'user_123' });
-            redis.get.mockResolvedValueOnce('1'); // cooldown active
+            redis.get.mockResolvedValueOnce('1'); // cooldown active — checked before findOne
             redis.ttl.mockResolvedValueOnce(45);
 
             await controller.requestPasswordReset(req, res);
 
+            expect(mockModel.findOne).not.toHaveBeenCalled(); // DB never queried
             expect(authEmailQueue.add).not.toHaveBeenCalled();
             expect(res.status).toHaveBeenCalledWith(429);
             expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
                 success: false,
                 message: expect.stringContaining('45 seconds')
             }));
+        });
+
+        test('sets cooldown for unknown email to prevent account enumeration', async () => {
+            const req = makeReq({ body: { email: 'unknown@user.com' } });
+            const res = makeRes();
+
+            redis.get.mockResolvedValueOnce(null); // no cooldown
+            mockModel.findOne.mockResolvedValueOnce(null); // user does not exist
+
+            await controller.requestPasswordReset(req, res);
+
+            const cooldownCall = redis.set.mock.calls.find(c => c[0].includes('otp:cooldown:reset'));
+            expect(cooldownCall).toBeDefined(); // cooldown set even for unknown email
+            expect(authEmailQueue.add).not.toHaveBeenCalled();
+            expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ message: expect.any(String) }));
         });
 
         test('sets cooldown after sending reset OTP', async () => {

--- a/apps/public-api/src/__tests__/userAuth.email.test.js
+++ b/apps/public-api/src/__tests__/userAuth.email.test.js
@@ -392,7 +392,8 @@ describe('Email Authentication Flow', () => {
             expect(authEmailQueue.add).not.toHaveBeenCalled();
             expect(res.status).toHaveBeenCalledWith(429);
             expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
-                error: expect.stringContaining('45 seconds')
+                success: false,
+                message: expect.stringContaining('45 seconds')
             }));
         });
 

--- a/apps/public-api/src/controllers/userAuth.controller.js
+++ b/apps/public-api/src/controllers/userAuth.controller.js
@@ -1329,20 +1329,28 @@ module.exports.requestPasswordReset = async (req, res) => {
     try {
         const project = req.project;
         const { email } = onlyEmailSchema.parse(req.body);
+        const normalizedEmail = email.toLowerCase().trim();
 
         const usersColConfig = project.collections.find(c => c.name === 'users');
         if (!usersColConfig) return res.status(404).json({ error: "Auth collection not found" });
 
         const connection = await getConnection(project._id);
         const Model = getCompiledModel(connection, usersColConfig, project._id, project.resources.db.isExternal);
-        
-        const user = await Model.findOne({ email });
+
+        const user = await Model.findOne({ email: normalizedEmail });
         if (!user) {
             return res.json({ message: "If that email exists, a reset code has been sent." });
         }
 
+        try {
+            await checkPublicOtpCooldown(project._id, normalizedEmail, 'reset');
+        } catch (cooldownErr) {
+            return res.status(cooldownErr.statusCode || 429).json({ error: cooldownErr.message });
+        }
+
         const otp = crypto.randomInt(100000, 1000000).toString();
-        await redis.set(`project:${project._id}:otp:reset:${email}`, otp, 'EX', 300);
+        await redis.set(`project:${project._id}:otp:reset:${normalizedEmail}`, otp, 'EX', 300);
+        await setPublicOtpCooldown(project._id, normalizedEmail, 'reset');
 
         await authEmailQueue.add('send-reset-email', { email, otp, type: 'password_reset', pname: project.name, projectId: String(project._id) });
 
@@ -1358,8 +1366,9 @@ module.exports.resetPasswordUser = async (req, res) => {
     try {
         const project = req.project;
         const { email, otp, newPassword } = resetPasswordSchema.parse(req.body);
+        const normalizedEmail = email.toLowerCase().trim();
 
-        const redisKey = `project:${project._id}:otp:reset:${email}`;
+        const redisKey = `project:${project._id}:otp:reset:${normalizedEmail}`;
         const storedOtp = await redis.get(redisKey);
 
         if (!storedOtp || storedOtp !== otp) {
@@ -1373,7 +1382,7 @@ module.exports.resetPasswordUser = async (req, res) => {
         if (!collection) return res.status(404).json({ error: "Auth collection not found" });
 
         const result = await collection.updateOne(
-            { email },
+            { email: normalizedEmail },
             { $set: { password: hashedPassword } }
         );
 

--- a/apps/public-api/src/controllers/userAuth.controller.js
+++ b/apps/public-api/src/controllers/userAuth.controller.js
@@ -964,7 +964,7 @@ module.exports.signup = async (req, res) => {
                 try {
                     await checkPublicOtpCooldown(project._id, normalizedEmail, 'verification');
                 } catch (cooldownErr) {
-                    return res.status(cooldownErr.statusCode || 429).json({ error: cooldownErr.message });
+                    return res.status(cooldownErr.statusCode || 429).json({ success: false, data: {}, message: cooldownErr.message });
                 }
 
                 const otp = crypto.randomInt(100000, 1000000).toString();
@@ -1300,7 +1300,7 @@ module.exports.resendVerificationOtp = async (req, res) => {
         try {
             await checkPublicOtpCooldown(project._id, normalizedEmail, 'verification');
         } catch (cooldownErr) {
-            return res.status(cooldownErr.statusCode || 429).json({ error: cooldownErr.message });
+            return res.status(cooldownErr.statusCode || 429).json({ success: false, data: {}, message: cooldownErr.message });
         }
 
         const otp = crypto.randomInt(100000, 1000000).toString();
@@ -1345,7 +1345,7 @@ module.exports.requestPasswordReset = async (req, res) => {
         try {
             await checkPublicOtpCooldown(project._id, normalizedEmail, 'reset');
         } catch (cooldownErr) {
-            return res.status(cooldownErr.statusCode || 429).json({ error: cooldownErr.message });
+            return res.status(cooldownErr.statusCode || 429).json({ success: false, data: {}, message: cooldownErr.message });
         }
 
         const otp = crypto.randomInt(100000, 1000000).toString();

--- a/apps/public-api/src/controllers/userAuth.controller.js
+++ b/apps/public-api/src/controllers/userAuth.controller.js
@@ -1337,15 +1337,16 @@ module.exports.requestPasswordReset = async (req, res) => {
         const connection = await getConnection(project._id);
         const Model = getCompiledModel(connection, usersColConfig, project._id, project.resources.db.isExternal);
 
-        const user = await Model.findOne({ email: normalizedEmail });
-        if (!user) {
-            return res.json({ message: "If that email exists, a reset code has been sent." });
-        }
-
         try {
             await checkPublicOtpCooldown(project._id, normalizedEmail, 'reset');
         } catch (cooldownErr) {
             return res.status(cooldownErr.statusCode || 429).json({ success: false, data: {}, message: cooldownErr.message });
+        }
+
+        const user = await Model.findOne({ email: normalizedEmail });
+        if (!user) {
+            await setPublicOtpCooldown(project._id, normalizedEmail, 'reset');
+            return res.json({ message: "If that email exists, a reset code has been sent." });
         }
 
         const otp = crypto.randomInt(100000, 1000000).toString();


### PR DESCRIPTION
Fixes #143

## 🛠️ Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🚀 What Changed

The `requestPasswordReset` endpoint had no cooldown between OTP requests, unlike `signup` and `resendVerificationOtp` which already enforced a 60-second window. This allowed an attacker who knows a valid email to flood that inbox with reset emails.

**Changes made:**
- Added `checkPublicOtpCooldown` before sending the reset OTP — returns HTTP 429 with seconds remaining if within the 60s window
- Added `setPublicOtpCooldown` after sending — sets a 60s Redis cooldown key (`otp:cooldown:reset:<email>`)
- Added `normalizedEmail` (`email.toLowerCase().trim()`) to `requestPasswordReset` and `resetPasswordUser` so OTP keys are case-insensitive and consistent

## 🧪 Testing & Validation
### Backend Verification:
- [x] I have run `npm test` in the `backend/` directory and all tests passed.
- [x] I have verified the API endpoints using Postman/Thunder Client.
- [x] New unit tests have been added (if applicable).

**New tests in `userAuth.email.test.js`:**
- Returns 429 with TTL when cooldown is active
- Cooldown key is set with 60s TTL after a successful send
- Normalized (lowercase) email is used in the Redis key
- Happy path (no active cooldown) still returns 200

**Manual verification (PowerShell):**
- 1st call → `200 { message: "If that email exists, a reset code has been sent." }`
- 2nd call immediately → `429 { error: "Please wait 57 seconds before requesting another code." }`

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] My changes generate no new warnings or errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Password reset, signup, and verification treat emails case-insensitively to avoid failed lookups.
  * OTP cooldowns are enforced consistently and return a standardized cooldown response including remaining seconds.
  * Cooldown keys are written even for unknown emails to prevent account enumeration; emails continue to be sent to the provided address.

* **Tests**
  * Added tests for OTP cooldown behavior, expiry messaging, cooldown writes for unknown emails, and email normalization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geturbackend/urBackend/pull/154)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->