### PR TITLE
feat(api): implement soft delete and trash cleanup worker

### DIFF
--- a/apps/dashboard-api/src/__tests__/project.controller.softDelete.test.js
+++ b/apps/dashboard-api/src/__tests__/project.controller.softDelete.test.js
@@ -13,6 +13,7 @@ jest.mock('@urbackend/common', () => ({
     },
     getConnection: jest.fn().mockResolvedValue({}),
     getCompiledModel: jest.fn(() => mockModel),
+    enqueueCollectionCleanup: jest.fn().mockResolvedValue(true)
 }));
 
 const { deleteRow } = require('../controllers/project.controller');
@@ -72,7 +73,7 @@ describe('Soft Delete in dashboard project.controller', () => {
         expect(res.json).toHaveBeenCalledWith({ 
             success: true, 
             data: { id: '507f1f77bcf86cd799439011' }, 
-            message: "Document deleted successfully." 
+            message: "Document moved to trash" 
         });
         
         // Should not save project (to update databaseUsed) since it's a soft delete

--- a/apps/dashboard-api/src/__tests__/project.controller.softDelete.test.js
+++ b/apps/dashboard-api/src/__tests__/project.controller.softDelete.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const mockFindOneAndUpdate = jest.fn();
+const mockFindOne = jest.fn();
+
+const mockModel = {
+    findOneAndUpdate: mockFindOneAndUpdate,
+};
+
+jest.mock('@urbackend/common', () => ({
+    Project: {
+        findOne: mockFindOne,
+    },
+    getConnection: jest.fn().mockResolvedValue({}),
+    getCompiledModel: jest.fn(() => mockModel),
+}));
+
+const { deleteRow } = require('../controllers/project.controller');
+
+function makeReq() {
+    return {
+        params: { projectId: 'proj_1', collectionName: 'posts', id: '507f1f77bcf86cd799439011' },
+        user: { _id: 'user_1' }
+    };
+}
+
+function makeRes() {
+    const res = {
+        statusCode: null,
+        body: null,
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+    };
+    return res;
+}
+
+describe('Soft Delete in dashboard project.controller', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('deleteRow sets isDeleted: true instead of hard deleting', async () => {
+        const req = makeReq();
+        const res = makeRes();
+
+        // Mock project
+        const project = {
+            _id: 'proj_1',
+            resources: { db: { isExternal: false } },
+            collections: [{ name: 'posts', model: [] }],
+            save: jest.fn().mockResolvedValue(true)
+        };
+        mockFindOne.mockResolvedValue(project);
+
+        // Mock document
+        const doc = { _id: '507f1f77bcf86cd799439011', isDeleted: false };
+        mockFindOneAndUpdate.mockReturnValue({
+            lean: jest.fn().mockResolvedValue(doc)
+        });
+
+        await deleteRow(req, res);
+
+        expect(mockFindOne).toHaveBeenCalled();
+        expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+            { _id: '507f1f77bcf86cd799439011', isDeleted: { $ne: true } },
+            expect.objectContaining({
+                $set: expect.objectContaining({ isDeleted: true, deletedAt: expect.any(Date) })
+            }),
+            { new: false }
+        );
+        
+        expect(res.json).toHaveBeenCalledWith({ 
+            success: true, 
+            data: { id: '507f1f77bcf86cd799439011' }, 
+            message: "Document deleted successfully." 
+        });
+        
+        // Should not save project (to update databaseUsed) since it's a soft delete
+        expect(project.save).not.toHaveBeenCalled();
+    });
+
+    test('deleteRow returns 404 if document is already soft-deleted or not found', async () => {
+        const req = makeReq();
+        const res = makeRes();
+
+        // Mock project
+        const project = {
+            _id: 'proj_1',
+            resources: { db: { isExternal: false } },
+            collections: [{ name: 'posts', model: [] }],
+            save: jest.fn().mockResolvedValue(true)
+        };
+        mockFindOne.mockResolvedValue(project);
+
+        mockFindOneAndUpdate.mockReturnValue({
+            lean: jest.fn().mockResolvedValue(null)
+        });
+
+        await deleteRow(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ 
+            success: false, 
+            data: {}, 
+            message: "Document not found." 
+        });
+    });
+});

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -37,6 +37,7 @@ const { getPublicIp } = require("@urbackend/common");
 const { clearCompiledModel } = require("@urbackend/common");
 const { createUniqueIndexes, ApiAnalytics, MailLog } = require("@urbackend/common");
 const { emitEvent } = require('../utils/emitEvent');
+const { enqueueCollectionCleanup } = require('@urbackend/common');
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 const SAFETY_MAX_BYTES = 100 * 1024 * 1024;
 const CONFIRM_UPLOAD_SIZE_TOLERANCE_BYTES = 64;
@@ -976,8 +977,9 @@ module.exports.deleteRow = async (req, res) => {
 
     // We don't decrement databaseUsed here because the document still occupies space.
     // It will be decremented during hard delete in the background worker.
+    await enqueueCollectionCleanup(projectId, collectionName);
 
-    res.json({ success: true, data: { id: result._id }, message: "Document deleted successfully." });
+    res.json({ success: true, data: { id: result._id }, message: "Document moved to trash" });
   } catch (err) {
     console.error("Delete Error:", err);
     res.status(500).json({ error: err.message });

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -977,7 +977,11 @@ module.exports.deleteRow = async (req, res) => {
 
     // We don't decrement databaseUsed here because the document still occupies space.
     // It will be decremented during hard delete in the background worker.
-    await enqueueCollectionCleanup(projectId, collectionName);
+    try {
+      await enqueueCollectionCleanup(projectId, collectionName);
+    } catch (err) {
+      console.error(`[TrashCleanup] Failed to enqueue cleanup for ${projectId}:${collectionName}`, err.message);
+    }
 
     res.json({ success: true, data: { id: result._id }, message: "Document moved to trash" });
   } catch (err) {

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -889,6 +889,10 @@ module.exports.insertData = async (req, res) => {
         .json({ error: "Collection configuration not found." });
     }
 
+    // Prevent manual injection of soft-delete fields
+    delete incomingData.isDeleted;
+    delete incomingData.deletedAt;
+
     let docSize = 0;
     if (!project.resources.db.isExternal) {
       docSize = Buffer.byteLength(JSON.stringify(incomingData));
@@ -955,21 +959,25 @@ module.exports.deleteRow = async (req, res) => {
       project.resources.db.isExternal,
     );
 
-    const docToDelete = await Model.findById(id);
-    if (!docToDelete) {
-      return res.status(404).json({ error: "Document not found." });
+    const result = await Model.findOneAndUpdate(
+      { _id: id, isDeleted: { $ne: true } },
+      {
+        $set: {
+          isDeleted: true,
+          deletedAt: new Date()
+        }
+      },
+      { new: false }
+    ).lean();
+
+    if (!result) {
+      return res.status(404).json({ success: false, data: {}, message: "Document not found." });
     }
 
-    const docSize = Buffer.byteLength(JSON.stringify(docToDelete));
+    // We don't decrement databaseUsed here because the document still occupies space.
+    // It will be decremented during hard delete in the background worker.
 
-    await Model.deleteOne({ _id: id });
-
-    if (!project.resources.db.isExternal) {
-      project.databaseUsed = Math.max(0, (project.databaseUsed || 0) - docSize);
-      await project.save();
-    }
-
-    res.json({ success: true, message: "Document deleted successfully" });
+    res.json({ success: true, data: { id: result._id }, message: "Document deleted successfully." });
   } catch (err) {
     console.error("Delete Error:", err);
     res.status(500).json({ error: err.message });
@@ -1009,10 +1017,14 @@ module.exports.editRow = async (req, res) => {
       });
     }
 
-    const docToEdit = await Model.findById(id);
+    const docToEdit = await Model.findOne({ _id: id, isDeleted: { $ne: true } });
     if (!docToEdit) {
       return res.status(404).json({ error: "Document not found." });
     }
+
+    // Prevent manual injection of soft-delete fields
+    delete req.body.isDeleted;
+    delete req.body.deletedAt;
 
     const oldSize = Buffer.byteLength(JSON.stringify(docToEdit.toObject()));
 

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -980,7 +980,7 @@ module.exports.deleteRow = async (req, res) => {
     try {
       await enqueueCollectionCleanup(projectId, collectionName);
     } catch (err) {
-      console.error(`[TrashCleanup] Failed to enqueue cleanup for ${projectId}:${collectionName}`, err.message);
+      console.error("Failed to enqueue trash cleanup job", err);
     }
 
     res.json({ success: true, data: { id: result._id }, message: "Document moved to trash" });

--- a/apps/dashboard-api/src/controllers/project.controller.js
+++ b/apps/dashboard-api/src/controllers/project.controller.js
@@ -980,7 +980,7 @@ module.exports.deleteRow = async (req, res) => {
     try {
       await enqueueCollectionCleanup(projectId, collectionName);
     } catch (err) {
-      console.error("Failed to enqueue trash cleanup job", err);
+      console.error("Failed to enqueue trash cleanup job", { projectId, collectionName, err });
     }
 
     res.json({ success: true, data: { id: result._id }, message: "Document moved to trash" });

--- a/apps/public-api/src/__tests__/aggregation.test.js
+++ b/apps/public-api/src/__tests__/aggregation.test.js
@@ -56,12 +56,13 @@ describe('aggregateData controller', () => {
     });
 
     test('executes a valid aggregation pipeline', async () => {
-        const req = makeReq();
+        const req = makeReq({ query: {} });
         const res = makeRes();
 
         await aggregateData(req, res);
 
         expect(mockAggregate).toHaveBeenCalledWith([
+            { $match: { isDeleted: { $ne: true } } },
             { $group: { _id: '$status', count: { $sum: 1 } } },
         ]);
         expect(res.statusCode).toBe(200);
@@ -74,6 +75,7 @@ describe('aggregateData controller', () => {
 
     test('prepends the RLS match stage when req.rlsFilter is set', async () => {
         const req = makeReq({
+            query: {},
             rlsFilter: { userId: 'user_1' },
             body: {
                 pipeline: [
@@ -87,9 +89,25 @@ describe('aggregateData controller', () => {
         await aggregateData(req, res);
 
         expect(mockAggregate).toHaveBeenCalledWith([
-            { $match: { userId: 'user_1' } },
+            { $match: { userId: 'user_1', isDeleted: { $ne: true } } },
             { $match: { status: 'published' } },
             { $sort: { createdAt: -1 } },
+        ]);
+        expect(res.statusCode).toBe(200);
+    });
+
+    test('includes soft-deleted documents when include_deleted=true is passed', async () => {
+        const req = makeReq({
+            query: { include_deleted: 'true' },
+            body: { pipeline: [{ $group: { _id: '$status', count: { $sum: 1 } } }] },
+        });
+        const res = makeRes();
+
+        await aggregateData(req, res);
+
+        expect(mockAggregate).toHaveBeenCalledWith([
+            { $match: {} }, // softDeleteFilter should be empty
+            { $group: { _id: '$status', count: { $sum: 1 } } },
         ]);
         expect(res.statusCode).toBe(200);
     });

--- a/apps/public-api/src/__tests__/data.controller.read.test.js
+++ b/apps/public-api/src/__tests__/data.controller.read.test.js
@@ -117,6 +117,7 @@ describe('data.controller read RLS filters', () => {
             $and: [
                 { _id: '507f1f77bcf86cd799439011' },
                 { userId: 'user_1' },
+                { isDeleted: { $ne: true } }
             ],
         });
         expect(res.json).toHaveBeenCalled();
@@ -193,5 +194,49 @@ describe('data.controller read RLS filters', () => {
         expect(mockPopulate).toHaveBeenCalledWith('category');
         expect(res.json).toHaveBeenCalled();
         expect(res.status).not.toHaveBeenCalledWith(500);
+    });
+
+    test('getSingleDoc excludes soft-deleted documents by default', async () => {
+        const req = makeReq();
+        const res = makeRes();
+
+        await getSingleDoc(req, res);
+
+        expect(mockFindOne).toHaveBeenCalled();
+        const findOneArgs = mockFindOne.mock.calls[0][0];
+        expect(findOneArgs.$and).toEqual(
+            expect.arrayContaining([
+                { _id: '507f1f77bcf86cd799439011' },
+                { isDeleted: { $ne: true } }
+            ])
+        );
+    });
+
+    test('getSingleDoc includes soft-deleted documents when include_deleted=true is passed', async () => {
+        const req = makeReq({ 
+            query: { include_deleted: 'true' },
+            rlsFilter: { ownerId: 'user_123' }
+        });
+        const res = makeRes();
+
+        await getSingleDoc(req, res);
+
+        expect(mockFindOne).toHaveBeenCalled();
+        const findOneArgs = mockFindOne.mock.calls[0][0];
+        
+        // Assert it contains the ID and RLS filter
+        expect(findOneArgs.$and).toContainEqual({ _id: '507f1f77bcf86cd799439011' });
+        expect(findOneArgs.$and).toContainEqual({ ownerId: 'user_123' });
+        
+        // Assert it does NOT contain the soft delete filter
+        expect(findOneArgs.$and).not.toContainEqual({ isDeleted: { $ne: true } });
+        
+        // Assert no other filters are present (length should be 3 if softDeleteFilter was {}, but it's {} so it shouldn't add much, let's check exact elements)
+        const softDeleteFilter = {}; // because include_deleted is true
+        expect(findOneArgs.$and).toEqual([
+            { _id: '507f1f77bcf86cd799439011' },
+            { ownerId: 'user_123' },
+            {} // empty object from softDeleteFilter
+        ]);
     });
 });

--- a/apps/public-api/src/__tests__/softDelete.test.js
+++ b/apps/public-api/src/__tests__/softDelete.test.js
@@ -18,7 +18,8 @@ jest.mock('@urbackend/common', () => ({
     QueryEngine: jest.fn(),
     validateData: jest.fn(),
     validateUpdateData: jest.fn(),
-    isValidId: () => true
+    isValidId: () => true,
+    enqueueCollectionCleanup: jest.fn().mockResolvedValue(true)
 }));
 
 const { deleteSingleDoc, getSingleDoc } = require('../controllers/data.controller');

--- a/apps/public-api/src/__tests__/softDelete.test.js
+++ b/apps/public-api/src/__tests__/softDelete.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const mockFindOneAndUpdate = jest.fn();
+const mockFindOne = jest.fn();
+const mockLean = jest.fn();
+
+const mockModel = {
+    findOneAndUpdate: mockFindOneAndUpdate,
+    findOne: mockFindOne,
+};
+
+jest.mock('@urbackend/common', () => ({
+    sanitize: (v) => v,
+    Project: {},
+    getConnection: jest.fn().mockResolvedValue({}),
+    getCompiledModel: jest.fn(() => mockModel),
+    dispatchWebhooks: jest.fn(),
+    QueryEngine: jest.fn(),
+    validateData: jest.fn(),
+    validateUpdateData: jest.fn(),
+    isValidId: () => true
+}));
+
+const { deleteSingleDoc, getSingleDoc } = require('../controllers/data.controller');
+
+function makeReq(overrides = {}) {
+    return {
+        params: { collectionName: 'posts', id: '507f1f77bcf86cd799439011' },
+        project: {
+            _id: 'proj_1',
+            resources: { db: { isExternal: false } },
+            collections: [{ name: 'posts', model: [] }],
+        },
+        query: {},
+        ...overrides,
+    };
+}
+
+function makeRes() {
+    const res = {
+        statusCode: null,
+        body: null,
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+    };
+    return res;
+}
+
+describe('Soft Delete in data.controller', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('deleteSingleDoc sets isDeleted: true instead of hard deleting', async () => {
+        const req = makeReq();
+        const res = makeRes();
+        const before = Date.now();
+
+        const doc = { _id: '507f1f77bcf86cd799439011', isDeleted: false };
+        mockFindOneAndUpdate.mockReturnValue({
+            lean: jest.fn().mockResolvedValue(doc)
+        });
+
+        await deleteSingleDoc(req, res);
+
+        expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+            expect.objectContaining({ _id: '507f1f77bcf86cd799439011', isDeleted: { $ne: true } }),
+            expect.objectContaining({
+                $set: expect.objectContaining({ isDeleted: true, deletedAt: expect.any(Date) })
+            }),
+            { new: false }
+        );
+
+        const deletedAt = mockFindOneAndUpdate.mock.calls[0][1].$set.deletedAt;
+        expect(deletedAt.getTime()).toBeGreaterThanOrEqual(before - 1000);
+        expect(deletedAt.getTime()).toBeLessThanOrEqual(Date.now() + 1000);
+        
+        expect(res.json).toHaveBeenCalledWith({ 
+            success: true, 
+            data: { id: '507f1f77bcf86cd799439011' }, 
+            message: "Document moved to trash" 
+        });
+    });
+
+    test('deleteSingleDoc returns 404 if document is already soft-deleted or not found', async () => {
+        const req = makeReq();
+        const res = makeRes();
+
+        mockFindOneAndUpdate.mockReturnValue({
+            lean: jest.fn().mockResolvedValue(null)
+        });
+
+        await deleteSingleDoc(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Document not found.' });
+    });
+});

--- a/apps/public-api/src/app.js
+++ b/apps/public-api/src/app.js
@@ -25,7 +25,7 @@ const {initWebhookWorker} = require('@urbackend/common');
 const {initAuthEmailWorker, initPublicEmailWorker} = require('@urbackend/common');
 const {initActivityRollupWorker, scheduleActivityRollup} = require('@urbackend/common');
 const {initReliabilityAlertWorker, scheduleReliabilityAlert} = require('@urbackend/common');
-const {initTrashCleanupWorker, scheduleTrashCleanup} = require('@urbackend/common');
+const {initTrashCleanupWorker} = require('@urbackend/common');
 
 app.use('/api/mail/webhook', express.raw({ type: 'application/json' }));
 app.use(express.json());
@@ -139,9 +139,6 @@ if (process.env.NODE_ENV !== 'test') {
             console.error('[ReliabilityAlert] Failed to schedule cron:', err.message)
         );
         initTrashCleanupWorker();
-        scheduleTrashCleanup().catch((err) =>
-            console.error('[TrashCleanup] Failed to schedule cron:', err.message)
-        );
     };
 
     const bootstrap = async () => {

--- a/apps/public-api/src/app.js
+++ b/apps/public-api/src/app.js
@@ -125,6 +125,7 @@ if (process.env.NODE_ENV !== 'test') {
     const PORT = process.env.USER_PORT || 1235;
 
     const { connectDB } = require('@urbackend/common');
+    let trashCleanupWorker;
 
     const startWorkers = () => {
         initWebhookWorker();
@@ -138,7 +139,7 @@ if (process.env.NODE_ENV !== 'test') {
         scheduleReliabilityAlert().catch((err) =>
             console.error('[ReliabilityAlert] Failed to schedule cron:', err.message)
         );
-        initTrashCleanupWorker();
+        trashCleanupWorker = initTrashCleanupWorker();
     };
 
     const bootstrap = async () => {
@@ -152,6 +153,15 @@ if (process.env.NODE_ENV !== 'test') {
         // SHUTDOWN
         const gracefulShutdown = async () => {
             console.log('🛑 SIGTERM/SIGINT received. Shutting down gracefully...');
+
+            if (trashCleanupWorker) {
+                try {
+                    await trashCleanupWorker.close();
+                    console.log('✅ Trash cleanup worker closed.');
+                } catch (err) {
+                    console.error('❌ Error closing trash cleanup worker:', err);
+                }
+            }
 
             server.close(async () => {
                 console.log('✅ HTTP server closed.');

--- a/apps/public-api/src/app.js
+++ b/apps/public-api/src/app.js
@@ -25,6 +25,7 @@ const {initWebhookWorker} = require('@urbackend/common');
 const {initAuthEmailWorker, initPublicEmailWorker} = require('@urbackend/common');
 const {initActivityRollupWorker, scheduleActivityRollup} = require('@urbackend/common');
 const {initReliabilityAlertWorker, scheduleReliabilityAlert} = require('@urbackend/common');
+const {initTrashCleanupWorker, scheduleTrashCleanup} = require('@urbackend/common');
 
 app.use('/api/mail/webhook', express.raw({ type: 'application/json' }));
 app.use(express.json());
@@ -136,6 +137,10 @@ if (process.env.NODE_ENV !== 'test') {
         initReliabilityAlertWorker();
         scheduleReliabilityAlert().catch((err) =>
             console.error('[ReliabilityAlert] Failed to schedule cron:', err.message)
+        );
+        initTrashCleanupWorker();
+        scheduleTrashCleanup().catch((err) =>
+            console.error('[TrashCleanup] Failed to schedule cron:', err.message)
         );
     };
 

--- a/apps/public-api/src/app.js
+++ b/apps/public-api/src/app.js
@@ -154,6 +154,12 @@ if (process.env.NODE_ENV !== 'test') {
         const gracefulShutdown = async () => {
             console.log('🛑 SIGTERM/SIGINT received. Shutting down gracefully...');
 
+            // Force close after 10s
+            const forceShutdown = setTimeout(() => {
+                console.error('Force shutting down...');
+                process.exit(1);
+            }, 10000);
+
             if (trashCleanupWorker) {
                 try {
                     await trashCleanupWorker.close();
@@ -168,18 +174,13 @@ if (process.env.NODE_ENV !== 'test') {
                 try {
                     await mongoose.connection.close(false);
                     console.log('✅ MongoDB connection closed.');
+                    clearTimeout(forceShutdown);
                     process.exit(0);
                 } catch (err) {
                     console.error('❌ Error closing MongoDB connection:', err);
                     process.exit(1);
                 }
             });
-
-            // Force close after 10s
-            setTimeout(() => {
-                console.error('Force shutting down...');
-                process.exit(1);
-            }, 10000);
         };
 
         process.on('SIGTERM', gracefulShutdown);

--- a/apps/public-api/src/controllers/data.controller.js
+++ b/apps/public-api/src/controllers/data.controller.js
@@ -8,7 +8,10 @@ const { validateData, validateUpdateData, aggregateSchema } = require("@urbacken
 const { performance } = require('perf_hooks');
 const { dispatchWebhooks } = require('../utils/webhookDispatcher');
 const { z } = require("zod");
-const { AppError } = require("@urbackend/common");
+const { 
+  AppError, 
+  enqueueCollectionCleanup 
+} = require("@urbackend/common");
 
 const isDebug = process.env.DEBUG === 'true';
 
@@ -54,7 +57,10 @@ module.exports.insertData = async (req, res) => {
 
     let docSize = 0;
     if (!project.resources.db.isExternal) {
-      docSize = Buffer.byteLength(JSON.stringify(safeData));
+      const docForSize = safeData._id
+        ? safeData
+        : { ...safeData, _id: new mongoose.Types.ObjectId() };
+      docSize = mongoose.mongo.BSON.calculateObjectSize(docForSize);
       if ((project.databaseUsed || 0) + docSize > project.databaseLimit) {
         return res.status(403).json({ error: "Database limit exceeded." });
       }
@@ -154,7 +160,12 @@ module.exports.insertData = async (req, res) => {
         // Prevent manual injection of soft-delete fields
         delete cleanData.isDeleted;
         delete cleanData.deletedAt;
-        validData.push(sanitize(cleanData));
+        
+        validData.push(sanitize({
+          ...cleanData,
+          isDeleted: false,
+          deletedAt: null
+        }));
       }
     });
 
@@ -589,6 +600,7 @@ module.exports.deleteSingleDoc = async (req, res) => {
 
     // We don't decrement databaseUsed here because the document still occupies space.
     // It will be decremented during hard delete in the background worker.
+    await enqueueCollectionCleanup(project._id, collectionName);
 
     dispatchWebhooks({
       projectId: project._id,

--- a/apps/public-api/src/controllers/data.controller.js
+++ b/apps/public-api/src/controllers/data.controller.js
@@ -600,7 +600,11 @@ module.exports.deleteSingleDoc = async (req, res) => {
 
     // We don't decrement databaseUsed here because the document still occupies space.
     // It will be decremented during hard delete in the background worker.
-    await enqueueCollectionCleanup(project._id, collectionName);
+    try {
+      await enqueueCollectionCleanup(project._id, collectionName);
+    } catch (err) {
+      console.error(`[TrashCleanup] Failed to enqueue cleanup for ${project._id}:${collectionName}`, err.message);
+    }
 
     dispatchWebhooks({
       projectId: project._id,

--- a/apps/public-api/src/controllers/data.controller.js
+++ b/apps/public-api/src/controllers/data.controller.js
@@ -46,6 +46,10 @@ module.exports.insertData = async (req, res) => {
     const { error, cleanData } = validateData(incomingData, schemaRules);
     if (error) return res.status(400).json({ error });
 
+    // Prevent manual injection of soft-delete fields
+    delete cleanData.isDeleted;
+    delete cleanData.deletedAt;
+
     const safeData = sanitize(cleanData);
 
     let docSize = 0;
@@ -147,6 +151,9 @@ module.exports.insertData = async (req, res) => {
       if (error) {
         invalidIndices.push(index);
       } else {
+        // Prevent manual injection of soft-delete fields
+        delete cleanData.isDeleted;
+        delete cleanData.deletedAt;
         validData.push(sanitize(cleanData));
       }
     });
@@ -333,7 +340,12 @@ module.exports.getSingleDoc = async (req, res) => {
     );
 
     const baseFilter = req.rlsFilter && typeof req.rlsFilter === 'object' ? req.rlsFilter : {};
-    let query = Model.findOne({ $and: [{ _id: id }, baseFilter] });
+    
+    // Soft delete filter
+    const includeDeleted = req.query.include_deleted === 'true';
+    const softDeleteFilter = includeDeleted ? {} : { isDeleted: { $ne: true } };
+
+    let query = Model.findOne({ $and: [{ _id: id }, baseFilter, softDeleteFilter] });
 
     if (req.query.fields) {
       query = query.select(req.query.fields.split(',').join(' '));
@@ -412,9 +424,27 @@ module.exports.aggregateData = async (req, res) => {
     const baseFilter =
       req.rlsFilter && typeof req.rlsFilter === "object" ? req.rlsFilter : {};
 
-    const effectivePipeline = Object.keys(baseFilter).length > 0
-      ? [{ $match: baseFilter }, ...pipeline]
-      : pipeline;
+    const includeDeleted = req.query?.include_deleted === 'true';
+    const softDeleteFilter = includeDeleted ? {} : { isDeleted: { $ne: true } };
+
+    const filter = { ...baseFilter, ...softDeleteFilter };
+
+    // $geoNear and $search must be the first stage in the pipeline if present
+    let effectivePipeline = [];
+    const firstStage = pipeline.length > 0 ? Object.keys(pipeline[0])[0] : null;
+    
+    if (firstStage === '$geoNear' || firstStage === '$search') {
+      effectivePipeline = [
+        pipeline[0],
+        { $match: filter },
+        ...pipeline.slice(1)
+      ];
+    } else {
+      effectivePipeline = [
+        { $match: filter },
+        ...pipeline
+      ];
+    }
 
     const data = await Model.aggregate(effectivePipeline);
 
@@ -479,10 +509,16 @@ module.exports.updateSingleData = async (req, res) => {
     if (validationError)
       return res.status(400).json({ error: validationError });
 
+    // Prevent manual injection of soft-delete fields
+    delete updateData.isDeleted;
+    delete updateData.deletedAt;
+
     const sanitizedData = sanitize(updateData);
 
-    const result = await Model.findByIdAndUpdate(
-      id,
+    const baseFilter = req.rlsFilter && typeof req.rlsFilter === 'object' ? req.rlsFilter : {};
+
+    const result = await Model.findOneAndUpdate(
+      { $and: [{ _id: id }, { isDeleted: { $ne: true } }, baseFilter] },
       { $set: sanitizedData },
       { new: true, runValidators: true },
     ).lean();
@@ -537,37 +573,32 @@ module.exports.deleteSingleDoc = async (req, res) => {
       project.resources.db.isExternal,
     );
 
-    const docToDelete = await Model.findById(id);
+    const result = await Model.findOneAndUpdate(
+      { _id: id, isDeleted: { $ne: true }, ...(req.rlsFilter || {}) },
+      { 
+        $set: { 
+          isDeleted: true, 
+          deletedAt: new Date() 
+        } 
+      },
+      { new: false } // return the original document for webhook
+    ).lean();
 
-    if (!docToDelete)
+    if (!result)
       return res.status(404).json({ error: "Document not found." });
 
-    const deletedDoc = docToDelete.toObject
-      ? docToDelete.toObject()
-      : { ...docToDelete._doc };
-
-    let docSize = 0;
-
-    if (!project.resources.db.isExternal) {
-      docSize = Buffer.byteLength(JSON.stringify(docToDelete));
-    }
-
-    await Model.deleteOne({ _id: id });
-
-    if (!project.resources.db.isExternal) {
-      let databaseUsed = Math.max(0, (project.databaseUsed || 0) - docSize);
-      await Project.updateOne({ _id: project._id }, { $set: { databaseUsed } });
-    }
+    // We don't decrement databaseUsed here because the document still occupies space.
+    // It will be decremented during hard delete in the background worker.
 
     dispatchWebhooks({
       projectId: project._id,
       collection: collectionName,
       action: 'delete',
-      document: deletedDoc,
+      document: result,
       documentId: id,
     });
 
-    res.json({ message: "Document deleted", id });
+    res.json({ success: true, data: { id }, message: "Document moved to trash" });
   } catch (err) {
     if (process.env.NODE_ENV !== 'test') {
       console.error(err);

--- a/apps/public-api/src/controllers/data.controller.js
+++ b/apps/public-api/src/controllers/data.controller.js
@@ -603,7 +603,7 @@ module.exports.deleteSingleDoc = async (req, res) => {
     try {
       await enqueueCollectionCleanup(project._id, collectionName);
     } catch (err) {
-      console.error("Failed to enqueue trash cleanup job", { projectId: string(project._id), collectionName,  err });
+      console.error("Failed to enqueue trash cleanup job", { projectId: String(project._id), collectionName,  err });
     }
 
     dispatchWebhooks({

--- a/apps/public-api/src/controllers/data.controller.js
+++ b/apps/public-api/src/controllers/data.controller.js
@@ -603,7 +603,7 @@ module.exports.deleteSingleDoc = async (req, res) => {
     try {
       await enqueueCollectionCleanup(project._id, collectionName);
     } catch (err) {
-      console.error(`[TrashCleanup] Failed to enqueue cleanup for ${project._id}:${collectionName}`, err.message);
+      console.error("Failed to enqueue trash cleanup job", err);
     }
 
     dispatchWebhooks({

--- a/apps/public-api/src/controllers/data.controller.js
+++ b/apps/public-api/src/controllers/data.controller.js
@@ -603,7 +603,7 @@ module.exports.deleteSingleDoc = async (req, res) => {
     try {
       await enqueueCollectionCleanup(project._id, collectionName);
     } catch (err) {
-      console.error("Failed to enqueue trash cleanup job", err);
+      console.error("Failed to enqueue trash cleanup job", { projectId: string(project._id), collectionName,  err });
     }
 
     dispatchWebhooks({

--- a/apps/web-dashboard/src/components/Database/DatabaseHeader.jsx
+++ b/apps/web-dashboard/src/components/Database/DatabaseHeader.jsx
@@ -7,7 +7,8 @@ import {
 const DatabaseHeader = ({ 
   project, activeCollection, dataLength, viewMode, setViewMode, 
   showFilterMenu, setShowFilterMenu, filtersCount, 
-  onRefresh, onRlsClick, onAddRecord, onOpenSidebar 
+  onRefresh, onRlsClick, onAddRecord, onOpenSidebar,
+  showDeleted, setShowDeleted
 }) => {
   return (
     <header className="db-header glass-panel" style={{ 
@@ -38,6 +39,12 @@ const DatabaseHeader = ({
 
       <div className="header-actions" style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
         <span style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)', marginRight: '10px' }}>{dataLength} Records</span>
+
+        {/* Soft Delete Toggle */}
+        <label style={{ fontSize: '0.75rem', color: 'var(--color-text-muted)', display: 'flex', alignItems: 'center', gap: '5px', cursor: 'pointer', marginRight: '10px' }}>
+            <input type="checkbox" checked={showDeleted} onChange={(e) => setShowDeleted(e.target.checked)} />
+            Show Deleted
+        </label>
 
         {/* View Toggles */}
         <div className="view-toggle" style={{ display: 'flex', background: 'rgba(255,255,255,0.05)', padding: '2px', borderRadius: '6px', gap: '2px' }}>

--- a/apps/web-dashboard/src/pages/Database.jsx
+++ b/apps/web-dashboard/src/pages/Database.jsx
@@ -31,6 +31,7 @@ export default function Database() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [showModal, setShowModal] = useState(false);
   const [selectedId, setSelectedId] = useState(null);
+  const [showDeleted, setShowDeleted] = useState(false);
   const [collectionToDelete, setCollectionToDelete] = useState(null);
   const [selectedRecord, setSelectedRecord] = useState(null);
   const [editingRecord, setEditingRecord] = useState(null);
@@ -100,6 +101,9 @@ export default function Database() {
     setLoadingData(true);
     try {
       let queryStr = `?page=${queryParams.page}&limit=${queryParams.limit}&sort=${queryParams.sort}`;
+      if (showDeleted) {
+        queryStr += `&include_deleted=true`;
+      }
       queryParams.filters.forEach(f => {
          if (f.field && f.value !== '') queryStr += `&${f.field}${f.operator === '=' ? '' : f.operator}=${encodeURIComponent(f.value)}`;
       });
@@ -114,7 +118,7 @@ export default function Database() {
       }
     } catch { toast.error("Failed to load data"); }
     finally { setLoadingData(false); }
-  }, [activeCollection, projectId, queryParams]);
+  }, [activeCollection, projectId, queryParams, showDeleted]);
 
   useEffect(() => {
     if (!activeCollection) return;
@@ -189,6 +193,8 @@ export default function Database() {
                 setIsAddModalOpen(true);
               }}
               onOpenSidebar={() => setIsSidebarOpen(true)}
+              showDeleted={showDeleted}
+              setShowDeleted={setShowDeleted}
             />
 
             <div className="db-content" style={{ flex: 1, overflow: 'hidden', position: 'relative', display: 'flex', flexDirection: 'column' }}>

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -51,7 +51,6 @@ const {
 const {
   trashCleanupQueue,
   enqueueCollectionCleanup,
-  scheduleTrashCleanup,
   initTrashCleanupWorker,
 } = require("./queues/trashCleanupQueue");
 
@@ -213,6 +212,5 @@ module.exports = {
   clearLockout,
   trashCleanupQueue,
   enqueueCollectionCleanup,
-  scheduleTrashCleanup,
   initTrashCleanupWorker,
 };

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -50,6 +50,7 @@ const {
 } = require("./queues/reliabilityAlertQueue");
 const {
   trashCleanupQueue,
+  enqueueCollectionCleanup,
   scheduleTrashCleanup,
   initTrashCleanupWorker,
 } = require("./queues/trashCleanupQueue");
@@ -211,6 +212,7 @@ module.exports = {
   recordFailedAttempt,
   clearLockout,
   trashCleanupQueue,
+  enqueueCollectionCleanup,
   scheduleTrashCleanup,
   initTrashCleanupWorker,
 };

--- a/packages/common/src/index.js
+++ b/packages/common/src/index.js
@@ -38,8 +38,21 @@ const {
   initWebhookWorker,
   generateSignature,
 } = require("./queues/webhookQueue");
-const { activityRollupQueue, scheduleActivityRollup, initActivityRollupWorker } = require('./queues/activityRollupQueue');
-const { reliabilityAlertQueue, scheduleReliabilityAlert, initReliabilityAlertWorker } = require('./queues/reliabilityAlertQueue');
+const {
+  activityRollupQueue,
+  scheduleActivityRollup,
+  initActivityRollupWorker,
+} = require("./queues/activityRollupQueue");
+const {
+  reliabilityAlertQueue,
+  scheduleReliabilityAlert,
+  initReliabilityAlertWorker,
+} = require("./queues/reliabilityAlertQueue");
+const {
+  trashCleanupQueue,
+  scheduleTrashCleanup,
+  initTrashCleanupWorker,
+} = require("./queues/trashCleanupQueue");
 
 // Middleware
 const checkAuthEnabled = require('./middleware/checkAuthEnabled')
@@ -197,4 +210,7 @@ module.exports = {
   checkLockout,
   recordFailedAttempt,
   clearLockout,
+  trashCleanupQueue,
+  scheduleTrashCleanup,
+  initTrashCleanupWorker,
 };

--- a/packages/common/src/queues/trashCleanupQueue.js
+++ b/packages/common/src/queues/trashCleanupQueue.js
@@ -12,12 +12,16 @@ const trashCleanupQueue = new Queue(QUEUE_NAME, { connection });
  */
 async function enqueueCollectionCleanup(projectId, collectionName, delay = 0) {
   try {
-    const jobId = `${projectId}:${collectionName}`;
+    const baseJobId = `${encodeURIComponent(projectId)}-${encodeURIComponent(collectionName)}`;
+    const jobId = delay > 0 ? `${baseJobId}-${Date.now()}` : baseJobId;
     
-    // Safely remove existing job
-    const oldJob = await trashCleanupQueue.getJob(jobId);
+    // Only remove non-active jobs to avoid BullMQ state errors
+    const oldJob = await trashCleanupQueue.getJob(baseJobId);
     if (oldJob) {
-        try { await oldJob.remove(); } catch (e) { console.warn(`[TrashCleanup] Could not remove existing job ${jobId}:`, e.message); }
+      const state = await oldJob.getState();
+      if (state === 'delayed' || state === 'waiting') {
+        try { await oldJob.remove(); } catch (e) { console.warn(`[TrashCleanup] Could not remove existing job ${baseJobId}:`, e.message); }
+      }
     }
 
     await trashCleanupQueue.add(

--- a/packages/common/src/queues/trashCleanupQueue.js
+++ b/packages/common/src/queues/trashCleanupQueue.js
@@ -5,195 +5,152 @@ const { getConnection } = require('../utils/connection.manager');
 const { getCompiledModel } = require('../utils/injectModel');
 
 const QUEUE_NAME = 'trash-cleanup-queue';
-
 const trashCleanupQueue = new Queue(QUEUE_NAME, { connection });
 
 /**
- * Enqueue a specific collection for soft-delete cleanup.
- * Uses jobId for deduplication so multiple deletes before the cron runs
- * only result in a single cleanup job.
+ * Enqueue a cleanup job for a specific collection.
  */
-async function enqueueCollectionCleanup(projectId, collectionName) {
+async function enqueueCollectionCleanup(projectId, collectionName, delay = 0) {
   try {
+    const jobId = `${projectId}:${collectionName}`;
+    
+    // Safely remove existing job
+    const oldJob = await trashCleanupQueue.getJob(jobId);
+    if (oldJob) {
+        try { await oldJob.remove(); } catch (e) { console.warn(`[TrashCleanup] Could not remove existing job ${jobId}:`, e.message); }
+    }
+
     await trashCleanupQueue.add(
       'cleanup-collection',
       { projectId, collectionName },
       {
-        jobId: `${projectId}:${collectionName}`, // Deduplication
-        removeOnComplete: true,
-        removeOnFail: true,
+        jobId: jobId,
+        delay: Math.max(delay, 0),
         attempts: 3,
-        backoff: { type: 'exponential', delay: 2000 }
+        backoff: { type: 'exponential', delay: 5000 },
+        removeOnComplete: { age: 86400 },
+        removeOnFail: true,
       }
     );
   } catch (err) {
-    console.error(`[TrashCleanup] Failed to enqueue collection cleanup for ${projectId}:${collectionName}`, err.message);
+    console.error(`[TrashCleanup] Failed to enqueue cleanup for ${projectId}:${collectionName}:`, err.message);
+    throw err;
   }
 }
 
 /**
- * Schedule the weekly trash cleanup job (fallback scan).
- * Runs at Wednesday 21:30 UTC = Thursday 03:00 IST.
+ * Process a collection cleanup job.
  */
-async function scheduleTrashCleanup() {
-  const existing = await trashCleanupQueue.getRepeatableJobs();
-  for (const job of existing) {
-    if (job.name === 'weekly-trash-cleanup' || job.name === 'daily-trash-cleanup') {
-      await trashCleanupQueue.removeRepeatableByKey(job.key);
-    }
-  }
+async function processCollectionCleanup(projectId, collectionName) {
+  const project = await Project.findById(projectId).lean();
+  if (!project) return;
 
-  await trashCleanupQueue.add(
-    'weekly-trash-cleanup',
-    {},
-    {
-      repeat: { 
-        pattern: '30 21 * * 3', // Wednesday 21:30 UTC
-        tz: 'UTC'
-      },
-      removeOnComplete: true,
-      removeOnFail: true,
-    }
-  );
-  console.log('[TrashCleanup] Weekly fallback cron scheduled (Thu 03:00 IST)');
-}
+  const collectionConfig = project.collections.find(c => c.name === collectionName);
+  if (!collectionConfig) return;
 
-async function processCollectionCleanup(project, collectionConfig, projectConn) {
-  const BATCH_SIZE = 500;
-
+  const projectConn = await getConnection(projectId);
   const Model = getCompiledModel(
     projectConn,
     collectionConfig,
-    project._id,
+    projectId,
     project.resources.db.isExternal
   );
 
-  const thirtyDaysAgo = new Date();
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  let totalReclaimedBytes = 0;
 
-  const deleteFilter = {
-    isDeleted: true,
-    deletedAt: { $lt: thirtyDaysAgo },
-  };
-
-  let totalDocsDeleted = 0;
-  let totalSpaceReclaimed = 0;
-
+  // 1. Batch-delete expired soft-deleted docs
   while (true) {
-    // Fetch a batch of IDs to delete and accurately measure their storage size using $bsonSize
-    const docsBatch = await Model.aggregate([
-      { $match: deleteFilter },
-      { $limit: BATCH_SIZE },
-      { $project: { _id: 1, size: { $bsonSize: "$$ROOT" } } }
-    ]);
-
-    if (docsBatch.length === 0) {
-      break;
+    let batch;
+    try {
+        batch = await Model.aggregate([
+          { $match: { isDeleted: true, deletedAt: { $lt: thirtyDaysAgo } } },
+          { $limit: 500 },
+          { $project: { _id: 1, bsonSize: { $bsonSize: '$$ROOT' } } },
+        ]);
+    } catch (e) {
+        // Fallback for older Mongo versions without $bsonSize
+        batch = await Model.find({ isDeleted: true, deletedAt: { $lt: thirtyDaysAgo } })
+            .select('_id')
+            .limit(500)
+            .lean();
     }
 
-    const idsToDelete = docsBatch.map(d => d._id);
-    const batchSizeBytes = docsBatch.reduce((sum, d) => sum + (d.size || 1024), 0);
+    if (!batch.length) break;
 
-    const result = await Model.deleteMany({
-      _id: { $in: idsToDelete },
-      ...deleteFilter,
+    const ids = batch.map(d => d._id);
+    const reclaimedBytes = batch.reduce((sum, d) => sum + (d.bsonSize || 1024), 0);
+
+    const { deletedCount } = await Model.deleteMany({ 
+        _id: { $in: ids },
+        isDeleted: true,
+        deletedAt: { $lt: thirtyDaysAgo }
     });
+    totalReclaimedBytes += (reclaimedBytes * (deletedCount / ids.length));
 
-    if (result && result.deletedCount > 0) {
-      const ratio = result.deletedCount / docsBatch.length;
-      const reclaimedForBatch = Math.round(batchSizeBytes * ratio);
-      
-      totalDocsDeleted += result.deletedCount;
-      totalSpaceReclaimed += reclaimedForBatch;
-      console.log(`[TrashCleanup] Attempted ${docsBatch.length}, deleted ${result.deletedCount} documents (approx ${reclaimedForBatch} bytes) from ${project.name}.${collectionConfig.name}`);
-    }
-    
-    // Break if we processed fewer than BATCH_SIZE (no more to fetch)
-    // or if nothing was deleted (failsafe to prevent infinite loop)
-    if (docsBatch.length < BATCH_SIZE || result.deletedCount === 0) {
-      break;
-    }
+    if (batch.length < 500) break;
   }
 
-  if (totalDocsDeleted > 0 && !project.resources.db.isExternal) {
-    // Single atomic pipeline update using $max to ensure it doesn't go below 0
+  // 2. Atomic databaseUsed decrement
+  if (totalReclaimedBytes > 0 && !project.resources.db.isExternal) {
     await Project.updateOne(
-      { _id: project._id },
-      [
-        { 
-          $set: { 
-            databaseUsed: { 
-              $max: [0, { $subtract: [{ $ifNull: ['$databaseUsed', 0] }, totalSpaceReclaimed] }] 
-            } 
+      { _id: projectId },
+      [{ 
+        $set: { 
+          databaseUsed: { 
+            $max: [0, { $subtract: [{ $ifNull: ['$databaseUsed', 0] }, totalReclaimedBytes] }] 
           } 
-        }
-      ]
+        } 
+      }]
     );
   }
+
+  // 3. Self-schedule
+  const nextPending = await Model.findOne(
+    { isDeleted: true, deletedAt: { $gte: thirtyDaysAgo } },
+    { deletedAt: 1 },
+    { sort: { deletedAt: 1 } }
+  ).lean();
+
+  if (nextPending && nextPending.deletedAt) {
+    const nextRunDelay = nextPending.deletedAt.getTime() + 30 * 24 * 60 * 60 * 1000 - Date.now();
+    const delay = Math.max(nextRunDelay, 0);
+    await enqueueCollectionCleanup(projectId, collectionName, delay);
+  }
 }
 
-/**
- * Run the full fallback scan logic.
- */
 async function runFullTrashCleanup() {
-  console.log('[TrashCleanup] Starting weekly fallback cleanup...');
-  
+  console.log('[TrashCleanup] Starting manual full sweep...');
   const projects = await Project.find({}).lean();
-
   for (const project of projects) {
-    try {
-      const projectConn = await getConnection(project._id);
-      for (const collectionConfig of project.collections) {
-        await processCollectionCleanup(project, collectionConfig, projectConn);
-      }
-    } catch (err) {
-      console.error(`[TrashCleanup] Failed to clean trash for project ${project._id}:`, err.message);
+    for (const col of project.collections) {
+      await enqueueCollectionCleanup(project._id.toString(), col.name);
     }
   }
-
-  console.log('[TrashCleanup] Weekly fallback cleanup finished.');
 }
 
-/**
- * Initialize the BullMQ worker for trash cleanup.
- */
 function initTrashCleanupWorker() {
   const worker = new Worker(
     QUEUE_NAME,
     async (job) => {
-      if (job.name === 'cleanup-collection') {
-        const { projectId, collectionName } = job.data;
-        console.log(`[TrashCleanup] Processing targeted cleanup for ${projectId}:${collectionName}`);
-        
-        const project = await Project.findById(projectId).lean();
-        if (!project) return;
-        
-        const collectionConfig = project.collections.find(c => c.name === collectionName);
-        if (!collectionConfig) return;
-
-        const projectConn = await getConnection(project._id);
-        await processCollectionCleanup(project, collectionConfig, projectConn);
-
-      } else if (job.name === 'weekly-trash-cleanup') {
-        await runFullTrashCleanup();
-      }
+      const { projectId, collectionName } = job.data;
+      await processCollectionCleanup(projectId, collectionName);
     },
     { connection, concurrency: 1 }
   );
 
-  worker.on('completed', (job) => console.log(`[TrashCleanup] Job ${job.name} completed successfully`));
+  worker.on('completed', (job) => console.log(`[TrashCleanup] Job ${job.id} completed successfully`));
   worker.on('failed', (job, err) =>
-    console.error(`[TrashCleanup] Job ${job.name} failed:`, err.message)
+    console.error(`[TrashCleanup] Job ${job ? job.id : 'unknown'} failed:`, err.message)
   );
 
-  console.log('[TrashCleanup] Worker initialized');
   return worker;
 }
 
 module.exports = {
   trashCleanupQueue,
   enqueueCollectionCleanup,
-  scheduleTrashCleanup,
   initTrashCleanupWorker,
-  runFullTrashCleanup
+  runFullTrashCleanup,
+  processCollectionCleanup
 };

--- a/packages/common/src/queues/trashCleanupQueue.js
+++ b/packages/common/src/queues/trashCleanupQueue.js
@@ -9,107 +9,146 @@ const QUEUE_NAME = 'trash-cleanup-queue';
 const trashCleanupQueue = new Queue(QUEUE_NAME, { connection });
 
 /**
- * Schedule the daily trash cleanup job.
- * Runs at 03:00 IST every day.
+ * Enqueue a specific collection for soft-delete cleanup.
+ * Uses jobId for deduplication so multiple deletes before the cron runs
+ * only result in a single cleanup job.
+ */
+async function enqueueCollectionCleanup(projectId, collectionName) {
+  try {
+    await trashCleanupQueue.add(
+      'cleanup-collection',
+      { projectId, collectionName },
+      {
+        jobId: `${projectId}:${collectionName}`, // Deduplication
+        removeOnComplete: true,
+        removeOnFail: true,
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 2000 }
+      }
+    );
+  } catch (err) {
+    console.error(`[TrashCleanup] Failed to enqueue collection cleanup for ${projectId}:${collectionName}`, err.message);
+  }
+}
+
+/**
+ * Schedule the weekly trash cleanup job (fallback scan).
+ * Runs at Wednesday 21:30 UTC = Thursday 03:00 IST.
  */
 async function scheduleTrashCleanup() {
   const existing = await trashCleanupQueue.getRepeatableJobs();
   for (const job of existing) {
-    if (job.name === 'daily-trash-cleanup') {
+    if (job.name === 'weekly-trash-cleanup' || job.name === 'daily-trash-cleanup') {
       await trashCleanupQueue.removeRepeatableByKey(job.key);
     }
   }
 
   await trashCleanupQueue.add(
-    'daily-trash-cleanup',
+    'weekly-trash-cleanup',
     {},
     {
       repeat: { 
-        pattern: '0 3 * * *', // 03:00 IST daily
-        tz: 'Asia/Kolkata',
+        pattern: '30 21 * * 3', // Wednesday 21:30 UTC
+        tz: 'UTC'
       },
       removeOnComplete: true,
-      removeOnFail: { count: 10 },
-    },
+      removeOnFail: true,
+    }
   );
-  console.log('[TrashCleanup] Daily cron scheduled (03:00 IST)');
+  console.log('[TrashCleanup] Weekly fallback cron scheduled (Thu 03:00 IST)');
+}
+
+async function processCollectionCleanup(project, collectionConfig, projectConn) {
+  const BATCH_SIZE = 500;
+
+  const Model = getCompiledModel(
+    projectConn,
+    collectionConfig,
+    project._id,
+    project.resources.db.isExternal
+  );
+
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  const deleteFilter = {
+    isDeleted: true,
+    deletedAt: { $lt: thirtyDaysAgo },
+  };
+
+  let totalDocsDeleted = 0;
+  let totalSpaceReclaimed = 0;
+
+  while (true) {
+    // Fetch a batch of IDs to delete and accurately measure their storage size using $bsonSize
+    const docsBatch = await Model.aggregate([
+      { $match: deleteFilter },
+      { $limit: BATCH_SIZE },
+      { $project: { _id: 1, size: { $bsonSize: "$$ROOT" } } }
+    ]);
+
+    if (docsBatch.length === 0) {
+      break;
+    }
+
+    const idsToDelete = docsBatch.map(d => d._id);
+    const batchSizeBytes = docsBatch.reduce((sum, d) => sum + (d.size || 1024), 0);
+
+    const result = await Model.deleteMany({
+      _id: { $in: idsToDelete },
+      ...deleteFilter,
+    });
+
+    if (result && result.deletedCount > 0) {
+      totalDocsDeleted += result.deletedCount;
+      totalSpaceReclaimed += batchSizeBytes;
+      console.log(`[TrashCleanup] Deleted batch of ${result.deletedCount} documents (${batchSizeBytes} bytes) from ${project.name}.${collectionConfig.name}`);
+    }
+    
+    // Break if we processed fewer than BATCH_SIZE (no more to fetch)
+    // or if nothing was deleted (failsafe to prevent infinite loop)
+    if (docsBatch.length < BATCH_SIZE || result.deletedCount === 0) {
+      break;
+    }
+  }
+
+  if (totalDocsDeleted > 0 && !project.resources.db.isExternal) {
+    // Single atomic pipeline update using $max to ensure it doesn't go below 0
+    await Project.updateOne(
+      { _id: project._id },
+      [
+        { 
+          $set: { 
+            databaseUsed: { 
+              $max: [0, { $subtract: [{ $ifNull: ['$databaseUsed', 0] }, totalSpaceReclaimed] }] 
+            } 
+          } 
+        }
+      ]
+    );
+  }
 }
 
 /**
- * Run the trash cleanup logic.
+ * Run the full fallback scan logic.
  */
-async function runTrashCleanup() {
-  console.log('[TrashCleanup] Starting daily cleanup...');
+async function runFullTrashCleanup() {
+  console.log('[TrashCleanup] Starting weekly fallback cleanup...');
   
   const projects = await Project.find({}).lean();
-  const thirtyDaysAgo = new Date();
-  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
   for (const project of projects) {
     try {
       const projectConn = await getConnection(project._id);
-      let totalSpaceReclaimed = 0;
-
       for (const collectionConfig of project.collections) {
-        const Model = getCompiledModel(
-          projectConn,
-          collectionConfig,
-          project._id,
-          project.resources.db.isExternal
-        );
-
-        const deleteFilter = {
-          isDeleted: true,
-          deletedAt: { $lt: thirtyDaysAgo },
-        };
-
-        // Find documents to be hard-deleted
-        const docsToDelete = await Model.find(deleteFilter).lean();
-
-        if (docsToDelete.length > 0) {
-          console.log(`[TrashCleanup] Deleting ${docsToDelete.length} documents from ${project.name}.${collectionConfig.name}`);
-          const idsToDelete = docsToDelete.map((doc) => doc._id);
-
-          await Model.deleteMany({
-            _id: { $in: idsToDelete },
-            ...deleteFilter,
-          });
-
-          if (!project.resources.db.isExternal) {
-            const remainingDocs = await Model.find({ _id: { $in: idsToDelete } })
-              .select('_id')
-              .lean();
-            const remainingIds = new Set(remainingDocs.map((doc) => doc._id.toString()));
-
-            let reclaimedForCollection = 0;
-            for (const doc of docsToDelete) {
-              if (!remainingIds.has(doc._id.toString())) {
-                reclaimedForCollection += Buffer.byteLength(JSON.stringify(doc));
-              }
-            }
-
-            totalSpaceReclaimed += reclaimedForCollection;
-          }
-        }
-      }
-
-      if (totalSpaceReclaimed > 0 && !project.resources.db.isExternal) {
-        await Project.updateOne(
-          { _id: project._id },
-          { $inc: { databaseUsed: -totalSpaceReclaimed } }
-        );
-        // Ensure databaseUsed doesn't go below 0
-        await Project.updateOne(
-            { _id: project._id, databaseUsed: { $lt: 0 } },
-            { $set: { databaseUsed: 0 } }
-        );
+        await processCollectionCleanup(project, collectionConfig, projectConn);
       }
     } catch (err) {
       console.error(`[TrashCleanup] Failed to clean trash for project ${project._id}:`, err.message);
     }
   }
 
-  console.log('[TrashCleanup] Daily cleanup finished.');
+  console.log('[TrashCleanup] Weekly fallback cleanup finished.');
 }
 
 /**
@@ -118,15 +157,30 @@ async function runTrashCleanup() {
 function initTrashCleanupWorker() {
   const worker = new Worker(
     QUEUE_NAME,
-    async () => {
-      await runTrashCleanup();
+    async (job) => {
+      if (job.name === 'cleanup-collection') {
+        const { projectId, collectionName } = job.data;
+        console.log(`[TrashCleanup] Processing targeted cleanup for ${projectId}:${collectionName}`);
+        
+        const project = await Project.findById(projectId).lean();
+        if (!project) return;
+        
+        const collectionConfig = project.collections.find(c => c.name === collectionName);
+        if (!collectionConfig) return;
+
+        const projectConn = await getConnection(project._id);
+        await processCollectionCleanup(project, collectionConfig, projectConn);
+
+      } else if (job.name === 'weekly-trash-cleanup') {
+        await runFullTrashCleanup();
+      }
     },
     { connection, concurrency: 1 }
   );
 
-  worker.on('completed', () => console.log('[TrashCleanup] Job completed successfully'));
+  worker.on('completed', (job) => console.log(`[TrashCleanup] Job ${job.name} completed successfully`));
   worker.on('failed', (job, err) =>
-    console.error('[TrashCleanup] Job failed:', err.message)
+    console.error(`[TrashCleanup] Job ${job.name} failed:`, err.message)
   );
 
   console.log('[TrashCleanup] Worker initialized');
@@ -135,7 +189,8 @@ function initTrashCleanupWorker() {
 
 module.exports = {
   trashCleanupQueue,
+  enqueueCollectionCleanup,
   scheduleTrashCleanup,
   initTrashCleanupWorker,
-  runTrashCleanup
+  runFullTrashCleanup
 };

--- a/packages/common/src/queues/trashCleanupQueue.js
+++ b/packages/common/src/queues/trashCleanupQueue.js
@@ -1,0 +1,141 @@
+const { Queue, Worker } = require('bullmq');
+const connection = require('../config/redis');
+const Project = require('../models/Project');
+const { getConnection } = require('../utils/connection.manager');
+const { getCompiledModel } = require('../utils/injectModel');
+
+const QUEUE_NAME = 'trash-cleanup-queue';
+
+const trashCleanupQueue = new Queue(QUEUE_NAME, { connection });
+
+/**
+ * Schedule the daily trash cleanup job.
+ * Runs at 03:00 IST every day.
+ */
+async function scheduleTrashCleanup() {
+  const existing = await trashCleanupQueue.getRepeatableJobs();
+  for (const job of existing) {
+    if (job.name === 'daily-trash-cleanup') {
+      await trashCleanupQueue.removeRepeatableByKey(job.key);
+    }
+  }
+
+  await trashCleanupQueue.add(
+    'daily-trash-cleanup',
+    {},
+    {
+      repeat: { 
+        pattern: '0 3 * * *', // 03:00 IST daily
+        tz: 'Asia/Kolkata',
+      },
+      removeOnComplete: true,
+      removeOnFail: { count: 10 },
+    },
+  );
+  console.log('[TrashCleanup] Daily cron scheduled (03:00 IST)');
+}
+
+/**
+ * Run the trash cleanup logic.
+ */
+async function runTrashCleanup() {
+  console.log('[TrashCleanup] Starting daily cleanup...');
+  
+  const projects = await Project.find({}).lean();
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+
+  for (const project of projects) {
+    try {
+      const projectConn = await getConnection(project._id);
+      let totalSpaceReclaimed = 0;
+
+      for (const collectionConfig of project.collections) {
+        const Model = getCompiledModel(
+          projectConn,
+          collectionConfig,
+          project._id,
+          project.resources.db.isExternal
+        );
+
+        const deleteFilter = {
+          isDeleted: true,
+          deletedAt: { $lt: thirtyDaysAgo },
+        };
+
+        // Find documents to be hard-deleted
+        const docsToDelete = await Model.find(deleteFilter).lean();
+
+        if (docsToDelete.length > 0) {
+          console.log(`[TrashCleanup] Deleting ${docsToDelete.length} documents from ${project.name}.${collectionConfig.name}`);
+          const idsToDelete = docsToDelete.map((doc) => doc._id);
+
+          await Model.deleteMany({
+            _id: { $in: idsToDelete },
+            ...deleteFilter,
+          });
+
+          if (!project.resources.db.isExternal) {
+            const remainingDocs = await Model.find({ _id: { $in: idsToDelete } })
+              .select('_id')
+              .lean();
+            const remainingIds = new Set(remainingDocs.map((doc) => doc._id.toString()));
+
+            let reclaimedForCollection = 0;
+            for (const doc of docsToDelete) {
+              if (!remainingIds.has(doc._id.toString())) {
+                reclaimedForCollection += Buffer.byteLength(JSON.stringify(doc));
+              }
+            }
+
+            totalSpaceReclaimed += reclaimedForCollection;
+          }
+        }
+      }
+
+      if (totalSpaceReclaimed > 0 && !project.resources.db.isExternal) {
+        await Project.updateOne(
+          { _id: project._id },
+          { $inc: { databaseUsed: -totalSpaceReclaimed } }
+        );
+        // Ensure databaseUsed doesn't go below 0
+        await Project.updateOne(
+            { _id: project._id, databaseUsed: { $lt: 0 } },
+            { $set: { databaseUsed: 0 } }
+        );
+      }
+    } catch (err) {
+      console.error(`[TrashCleanup] Failed to clean trash for project ${project._id}:`, err.message);
+    }
+  }
+
+  console.log('[TrashCleanup] Daily cleanup finished.');
+}
+
+/**
+ * Initialize the BullMQ worker for trash cleanup.
+ */
+function initTrashCleanupWorker() {
+  const worker = new Worker(
+    QUEUE_NAME,
+    async () => {
+      await runTrashCleanup();
+    },
+    { connection, concurrency: 1 }
+  );
+
+  worker.on('completed', () => console.log('[TrashCleanup] Job completed successfully'));
+  worker.on('failed', (job, err) =>
+    console.error('[TrashCleanup] Job failed:', err.message)
+  );
+
+  console.log('[TrashCleanup] Worker initialized');
+  return worker;
+}
+
+module.exports = {
+  trashCleanupQueue,
+  scheduleTrashCleanup,
+  initTrashCleanupWorker,
+  runTrashCleanup
+};

--- a/packages/common/src/queues/trashCleanupQueue.js
+++ b/packages/common/src/queues/trashCleanupQueue.js
@@ -100,9 +100,12 @@ async function processCollectionCleanup(project, collectionConfig, projectConn) 
     });
 
     if (result && result.deletedCount > 0) {
+      const ratio = result.deletedCount / docsBatch.length;
+      const reclaimedForBatch = Math.round(batchSizeBytes * ratio);
+      
       totalDocsDeleted += result.deletedCount;
-      totalSpaceReclaimed += batchSizeBytes;
-      console.log(`[TrashCleanup] Deleted batch of ${result.deletedCount} documents (${batchSizeBytes} bytes) from ${project.name}.${collectionConfig.name}`);
+      totalSpaceReclaimed += reclaimedForBatch;
+      console.log(`[TrashCleanup] Attempted ${docsBatch.length}, deleted ${result.deletedCount} documents (approx ${reclaimedForBatch} bytes) from ${project.name}.${collectionConfig.name}`);
     }
     
     // Break if we processed fewer than BATCH_SIZE (no more to fetch)

--- a/packages/common/src/queues/trashCleanupQueue.js
+++ b/packages/common/src/queues/trashCleanupQueue.js
@@ -12,15 +12,14 @@ const trashCleanupQueue = new Queue(QUEUE_NAME, { connection });
  */
 async function enqueueCollectionCleanup(projectId, collectionName, delay = 0) {
   try {
-    const baseJobId = `${encodeURIComponent(projectId)}-${encodeURIComponent(collectionName)}`;
-    const jobId = delay > 0 ? `${baseJobId}-${Date.now()}` : baseJobId;
+    const jobId = `${projectId}:${collectionName}`;
     
-    // Only remove non-active jobs to avoid BullMQ state errors
-    const oldJob = await trashCleanupQueue.getJob(baseJobId);
+    // Safely remove existing job if it's not active to replace the schedule
+    const oldJob = await trashCleanupQueue.getJob(jobId);
     if (oldJob) {
       const state = await oldJob.getState();
       if (state === 'delayed' || state === 'waiting') {
-        try { await oldJob.remove(); } catch (e) { console.warn(`[TrashCleanup] Could not remove existing job ${baseJobId}:`, e.message); }
+        try { await oldJob.remove(); } catch (e) { console.warn(`[TrashCleanup] Could not remove existing job ${jobId}:`, e.message); }
       }
     }
 
@@ -28,12 +27,12 @@ async function enqueueCollectionCleanup(projectId, collectionName, delay = 0) {
       'cleanup-collection',
       { projectId, collectionName },
       {
-        jobId: jobId,
+        jobId: jobId, // Deterministic ID for deduplication and replacing schedules
         delay: Math.max(delay, 0),
         attempts: 3,
         backoff: { type: 'exponential', delay: 5000 },
         removeOnComplete: { age: 86400 },
-        removeOnFail: true,
+        removeOnFail: false, // Keep failed jobs visible for debugging
       }
     );
   } catch (err) {

--- a/packages/common/src/utils/__tests__/queryEngine.test.js
+++ b/packages/common/src/utils/__tests__/queryEngine.test.js
@@ -24,7 +24,7 @@ describe('QueryEngine', () => {
         const engine = new QueryEngine(mockQuery, queryString);
         engine.filter();
 
-        expect(mockQuery.find).toHaveBeenCalledWith({ name: 'John' });
+        expect(mockQuery.find).toHaveBeenCalledWith({ name: 'John', isDeleted: { $ne: true } });
     });
 
     test('should apply existing comparison operators (_gt, _lt, etc)', () => {
@@ -33,7 +33,8 @@ describe('QueryEngine', () => {
         engine.filter();
 
         expect(mockQuery.find).toHaveBeenCalledWith({
-            age: { $gt: '18', $lt: '30' }
+            age: { $gt: '18', $lt: '30' },
+            isDeleted: { $ne: true }
         });
     });
 
@@ -43,7 +44,8 @@ describe('QueryEngine', () => {
         engine.filter();
 
         expect(mockQuery.find).toHaveBeenCalledWith({
-            status: { $ne: 'inactive' }
+            status: { $ne: 'inactive' },
+            isDeleted: { $ne: true }
         });
     });
 
@@ -52,7 +54,7 @@ describe('QueryEngine', () => {
         const engine = new QueryEngine(mockQuery, queryString);
         engine.filter();
 
-        expect(mockQuery.find).toHaveBeenCalledWith({ name: 'John' });
+        expect(mockQuery.find).toHaveBeenCalledWith({ name: 'John', isDeleted: { $ne: true } });
         // page and sort should NOT be in the find() call
         const filterArg = mockQuery.find.mock.calls[0][0];
         expect(filterArg).not.toHaveProperty('page');
@@ -65,7 +67,8 @@ describe('QueryEngine', () => {
         engine.filter();
 
         expect(mockQuery.find).toHaveBeenCalledWith({
-            status: { $in: ['active', 'pending', 'archived'] }
+            status: { $in: ['active', 'pending', 'archived'] },
+            isDeleted: { $ne: true }
         });
     });
 
@@ -75,7 +78,8 @@ describe('QueryEngine', () => {
         engine.filter();
 
         expect(mockQuery.find).toHaveBeenCalledWith({
-            status: { $in: ['active', 'pending'] }
+            status: { $in: ['active', 'pending'] },
+            isDeleted: { $ne: true }
         });
     });
 
@@ -86,7 +90,8 @@ describe('QueryEngine', () => {
 
         expect(mockQuery.find).toHaveBeenCalledWith({
             email: { $exists: true },
-            phone: { $exists: false }
+            phone: { $exists: false },
+            isDeleted: { $ne: true }
         });
     });
 
@@ -100,6 +105,33 @@ describe('QueryEngine', () => {
         expect(filterArg.name.$regex.source).toBe('John');
         expect(filterArg.name.$regex.flags).toContain('i');
         expect(mockQuery.maxTimeMS).toHaveBeenCalledWith(QueryEngine.REGEX_MAX_TIME_MS);
+    });
+
+    test('should exclude soft-deleted documents by default', () => {
+        const queryString = { name: 'test' };
+        const engine = new QueryEngine(mockQuery, queryString);
+        
+        engine.filter();
+        
+        expect(mockQuery.find).toHaveBeenCalledWith(expect.objectContaining({
+            name: 'test',
+            isDeleted: { $ne: true }
+        }));
+    });
+
+    test('should include soft-deleted documents when include_deleted=true is passed', () => {
+        const queryString = { name: 'test', include_deleted: 'true' };
+        const engine = new QueryEngine(mockQuery, queryString);
+        
+        engine.filter();
+        
+        expect(mockQuery.find).toHaveBeenCalledWith({
+            name: 'test'
+        });
+        
+        const callArgs = mockQuery.find.mock.calls[0][0];
+        expect(callArgs).not.toHaveProperty('include_deleted');
+        expect(callArgs).not.toHaveProperty('isDeleted');
     });
 
     test('should throw a query validation error for invalid _regex pattern', () => {

--- a/packages/common/src/utils/injectModel.js
+++ b/packages/common/src/utils/injectModel.js
@@ -105,10 +105,19 @@ function buildMongooseSchema(fieldsArray = [], projectId, isExternal, isUsersCol
     schemaDef[normalizedKey] = buildFieldDef(field, projectId, isExternal, isUsersCollection);
   });
 
-  return new mongoose.Schema(schemaDef, {
+  // Explicitly add soft-delete fields to ensure schema consistency on inserts
+  schemaDef.isDeleted = { type: Boolean, default: false };
+  schemaDef.deletedAt = { type: Date, default: null };
+
+  const schema = new mongoose.Schema(schemaDef, {
     timestamps: true,
     strict: false,
   });
+
+  // Compound index to optimize the daily trash cleanup worker
+  schema.index({ isDeleted: 1, deletedAt: 1 });
+
+  return schema;
 }
 function getCompiledModel(connection, collectionData, projectId, isExternal) {
   let collectionName = "";

--- a/packages/common/src/utils/queryEngine.js
+++ b/packages/common/src/utils/queryEngine.js
@@ -29,9 +29,28 @@ class QueryEngine {
         const queryObj = { ...this.queryString };
         this.hasRegexFilter = false;
         
+        const includeDeleted = queryObj.include_deleted === 'true';
+        
+        // Prevent manual override of internal soft-delete fields
+        // Strip both exact matches and operator-suffixed variants (e.g., isDeleted_ne)
+        for (const key in queryObj) {
+            if (
+                key === 'include_deleted' ||
+                key.startsWith('isDeleted') ||
+                key.startsWith('deletedAt')
+            ) {
+                delete queryObj[key];
+            }
+        }
+
         QueryEngine.EXCLUDED_FIELDS.forEach(el => delete queryObj[el]);
 
         const mongoQuery = {};
+
+        if (!includeDeleted) {
+            mongoQuery.isDeleted = { $ne: true };
+        }
+
         for (const key in queryObj) {
             if (key.endsWith('_gt')) {
                 const field = key.replace(/_gt$/, '');


### PR DESCRIPTION
 Fixes #179

  Implemented a comprehensive Soft Delete system across the Public API and Dashboard. Instead of immediate removal, documents are now moved to a "trash" state for a 30-day grace period. A background worker automatically handles permanent purging of expired data while reclaiming database space.

  Key Changes:
   - Soft Delete Logic: Modified deleteSingleDoc and dashboard deleteRow to flag documents with isDeleted: true and deletedAt: Date.
   - Read Filtering: Enhanced the QueryEngine to automatically exclude soft-deleted documents from all queries and aggregations by default.
   - Manual Recovery/Audit: Added support for an include_deleted=true query parameter to allow developers and admins to view trashed data.
   - Automated Cleanup: Built a BullMQ-powered background worker that runs daily at 03:00 IST (21:30 UTC) to hard-delete documents older than 30 days and update project database usage stats.
   - Dashboard Integration: Updated the Web Dashboard UI with a "Show Deleted" toggle to manage trashed documents.

  🛠️ Type of Change
   - [x] ✨ New feature (non-breaking change which adds functionality)
   - [x] 🎨 UI/UX improvement 


  🧪 Testing & Validation
  Backend Verification:
   - [x] I have run npm test in the apps/public-api/ and apps/dashboard-api/ directories and all 257 tests passed.
   - [x] I have verified the API endpoints using Postman (Delete moves to trash, GET hides by default, include_deleted=true reveals them).
   - [x] New unit tests have been added in:
       - apps/public-api/src/__tests__/softDelete.test.js
       - apps/dashboard-api/src/__tests__/project.controller.softDelete.test.js
       - packages/common/src/utils/__tests__/queryEngine.test.js

  Frontend Verification:
   - [x] I have run npm run lint in the web-dashboard directory.
   - [x] Verified the "Show Deleted" toggle UI on different screen sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Soft delete: records are moved to trash (flagged with deletion time), excluded by default; background cleanup permanently removes items older than 30 days and is started/stopped with the server.
  * Dashboard: header toggle to show/hide deleted records; reads/aggregations support include_deleted=true.

* **Bug Fixes**
  * Clients can no longer set soft-delete metadata; read/update/delete now ignore already-deleted items and report "Document moved to trash" on soft delete.

* **Tests**
  * Added coverage for soft-delete behavior across controllers, aggregation, query handling, and cleanup scheduling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geturbackend/urBackend/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->