### PR TITLE
fix(dashboard): make database empty state cURL snippet RLS-aware to prevent 403 errors

### DIFF
--- a/apps/web-dashboard/src/pages/Database.jsx
+++ b/apps/web-dashboard/src/pages/Database.jsx
@@ -152,6 +152,11 @@ export default function Database() {
     } catch { toast.error("Failed to delete document"); }
   };
 
+  /**
+   * Generates an RLS-aware cURL snippet for the active collection.
+   * Uses the secret key if RLS is disabled, or the publishable key with a JWT if RLS is enabled.
+   * @returns {string} The cURL command snippet
+   */
   const getCurlSnippet = () => {
     if (!activeCollection) return '';
     return activeCollection.rls?.enabled
@@ -224,9 +229,13 @@ export default function Database() {
                             <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '10px', fontSize: '0.75rem', fontWeight: 600, color: 'var(--color-text-muted)', textTransform: 'uppercase' }}>
                                 <span>Example POST Request</span>
                                 <button 
-                                    onClick={() => { 
-                                        navigator.clipboard.writeText(getCurlSnippet()); 
-                                        toast.success('Snippet copied!'); 
+                                    onClick={async () => { 
+                                        try {
+                                            await navigator.clipboard.writeText(getCurlSnippet()); 
+                                            toast.success('Snippet copied!'); 
+                                        } catch {
+                                            toast.error('Failed to copy snippet');
+                                        }
                                     }} 
                                     style={{ background: 'none', border: 'none', color: 'var(--color-primary)', cursor: 'pointer' }}
                                 >

--- a/apps/web-dashboard/src/pages/Database.jsx
+++ b/apps/web-dashboard/src/pages/Database.jsx
@@ -152,6 +152,13 @@ export default function Database() {
     } catch { toast.error("Failed to delete document"); }
   };
 
+  const getCurlSnippet = () => {
+    if (!activeCollection) return '';
+    return activeCollection.rls?.enabled
+      ? `curl -X POST https://api.urbackend.com/api/data/${activeCollection.name} \\\n  -H "x-api-key: <YOUR_PUBLISHABLE_KEY>" \\\n  -H "Authorization: Bearer <USER_JWT>" \\\n  -H "Content-Type: application/json" \\\n  -d '{}'`
+      : `curl -X POST https://api.urbackend.com/api/data/${activeCollection.name} \\\n  -H "x-api-key: <YOUR_SECRET_KEY>" \\\n  -H "Content-Type: application/json" \\\n  -d '{}'`;
+  };
+
   return (
     <div className="db-layout" style={{ height: 'calc(100vh - var(--header-height))', display: 'flex', background: 'var(--color-bg-main)' }}>
       <DatabaseSidebar
@@ -218,8 +225,7 @@ export default function Database() {
                                 <span>Example POST Request</span>
                                 <button 
                                     onClick={() => { 
-                                        const snippet = `curl -X POST https://api.urbackend.com/api/data/${activeCollection.name} \\\n  -H "x-api-key: <YOUR_PUBLISHABLE_KEY>" \\\n  -H "Content-Type: application/json" \\\n  -d '{}'`;
-                                        navigator.clipboard.writeText(snippet); 
+                                        navigator.clipboard.writeText(getCurlSnippet()); 
                                         toast.success('Snippet copied!'); 
                                     }} 
                                     style={{ background: 'none', border: 'none', color: 'var(--color-primary)', cursor: 'pointer' }}
@@ -227,12 +233,22 @@ export default function Database() {
                                     Copy
                                 </button>
                             </div>
+                            {activeCollection?.rls?.enabled ? (
                             <pre style={{ margin: 0, fontFamily: 'monospace', fontSize: '0.85rem', color: '#e2e8f0', overflowX: 'auto', whiteSpace: 'pre-wrap' }}>
 <span style={{ color: '#f59e0b' }}>curl</span> -X POST https://api.urbackend.com/api/data/{activeCollection.name} \
   -H <span style={{ color: '#10b981' }}>"x-api-key: &lt;YOUR_PUBLISHABLE_KEY&gt;"</span> \
+  -H <span style={{ color: '#10b981' }}>"Authorization: Bearer &lt;USER_JWT&gt;"</span> \
   -H <span style={{ color: '#10b981' }}>"Content-Type: application/json"</span> \
   -d <span style={{ color: '#10b981' }}>'&#123;&#125;'</span>
                             </pre>
+                            ) : (
+                            <pre style={{ margin: 0, fontFamily: 'monospace', fontSize: '0.85rem', color: '#e2e8f0', overflowX: 'auto', whiteSpace: 'pre-wrap' }}>
+<span style={{ color: '#f59e0b' }}>curl</span> -X POST https://api.urbackend.com/api/data/{activeCollection.name} \
+  -H <span style={{ color: '#10b981' }}>"x-api-key: &lt;YOUR_SECRET_KEY&gt;"</span> \
+  -H <span style={{ color: '#10b981' }}>"Content-Type: application/json"</span> \
+  -d <span style={{ color: '#10b981' }}>'&#123;&#125;'</span>
+                            </pre>
+                            )}
                         </div>
                         <div style={{ marginTop: '1.5rem' }}>
                             <button className="btn btn-primary" onClick={() => setIsAddModalOpen(true)}>Add Record Manually</button>


### PR DESCRIPTION
### 🐛 The Problem
When a developer creates a new collection, the "No records found" empty state provides a helpful cURL snippet to make their first `POST` request. However, this snippet currently hardcodes `x-api-key: <YOUR_PUBLISHABLE_KEY>`. 

Because urBackend enforces secure defaults, RLS is disabled upon creation. Attempting to write with a publishable key while RLS is disabled results in a guaranteed **403 Forbidden error**, severely degrading the first-time developer experience.

### 🔍 The Root Cause
The snippet template literal inside `apps/web-dashboard/src/pages/Database.jsx` was a static string that did not account for the `activeCollection.rls.enabled` state.

### 💡 The Solution
Dynamically adapt the provided cURL snippet based on the active collection's RLS configuration, ensuring developers are always given a snippet that will result in a `200 OK` response.

### 🛠️ Implementation Details
- Abstracted the snippet generation logic into a clean `getCurlSnippet` helper method to eliminate duplication between the clipboard text and the visual markup.
- Added conditional logic reading from `activeCollection?.rls?.enabled`:
  - **If RLS is disabled (default):** The snippet replaces the publishable key placeholder with `<YOUR_SECRET_KEY>`.
  - **If RLS is enabled:** The snippet retains `<YOUR_PUBLISHABLE_KEY>` but correctly appends `-H "Authorization: Bearer <USER_JWT>"`.
- Updated the visual `<pre>` block conditionally to match the clipboard string.

### 📂 Affected Files
- `apps/web-dashboard/src/pages/Database.jsx`

### ✅ Testing Performed
- [x] Toggled RLS on/off locally and verified the UI immediately updates both the `<pre>` block and the clipboard payload.
- [x] Verified copied clipboard text formatting executes cleanly in a standard UNIX shell without syntax errors.
- [x] Ran `npm run lint` — 0 warnings.
- [x] Ran `npm run build` — Production Vite bundle builds successfully.

### 🛡️ Edge Cases Handled
- **Secret Key Exposure:** The dashboard API strips the actual `secretKey` from the frontend payload. The snippet safely uses the literal placeholder string `<YOUR_SECRET_KEY>`.
- **Undefined Contexts:** Safely defaults to the standard snippet using optional chaining (`activeCollection?.rls?.enabled`) if the component mounts before the full RLS object hydrates.

### 🔮 Future Considerations
If urBackend eventually supports generating temporary development JWTs directly from the dashboard, we could replace the `<USER_JWT>` placeholder with an actual valid test token for even smoother onboarding.

---

### 📝 Maintainer Summary & Review Notes

**Maintainer Summary**
This is a high-ROI, minimal-risk DX fix. It removes a major friction point where new users were failing their very first API test due to mismatched default security policies. The fix is strictly contained to UI rendering in `Database.jsx`.

**Review Notes**
- *Why is the `<pre>` block duplicated in the JSX?* 
While the string logic was abstracted into `getCurlSnippet()`, the visual `<pre>` block is duplicated using a ternary. This is an intentional tradeoff. Because the `<pre>` block relies heavily on strict whitespace and inline `<span>` tags for syntax highlighting, attempting to use conditional JSX fragments inside the `<pre>` tag resulted in severely degraded readability and a risk of malformed whitespace. The 6-line duplication is far cleaner.

**Possible Follow-up Improvements**
- **API Key Injector:** In the future, we could securely fetch and inject the actual `sk_live_` key into the `<YOUR_SECRET_KEY>` placeholder if the user clicks a "Reveal Secrets" toggle.
- **Snippet Ecosystem:** Consider abstracting the snippet blocks into a shared `<CodeSnippet>` component that supports rendering fetch/axios/cURL variants based on user preference.

**Resolves:** Fixes #189


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API example code snippets in the database section now dynamically adapt to your Row-Level Security setting, showing the correct authentication format (publishable-key + JWT when RLS is enabled, or secret key when disabled).
  * The copy-to-clipboard button now copies the exact, context-aware cURL example so pasted examples match your security configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geturbackend/urBackend/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->