### PR TITLE
fix(auth): add timeout handling for OAuth fetch requests

### DIFF
--- a/apps/dashboard-api/src/controllers/auth.controller.js
+++ b/apps/dashboard-api/src/controllers/auth.controller.js
@@ -12,9 +12,9 @@ const {
     deleteAccountSchema,
     onlyEmailSchema,
     resetPasswordSchema,
-    verifyOtpSchema
+    verifyOtpSchema,
+    AppError
 } = require("@urbackend/common");
-const AppError = require("@urbackend/common/src/utils/AppError");
 const { emitEvent } = require('../utils/emitEvent');
 
 const ACCESS_TOKEN_EXPIRES_IN = '15m';

--- a/apps/dashboard-api/src/controllers/auth.controller.js
+++ b/apps/dashboard-api/src/controllers/auth.controller.js
@@ -14,6 +14,7 @@ const {
     resetPasswordSchema,
     verifyOtpSchema
 } = require("@urbackend/common");
+const AppError = require("@urbackend/common/src/utils/AppError");
 const { emitEvent } = require('../utils/emitEvent');
 
 const ACCESS_TOKEN_EXPIRES_IN = '15m';
@@ -87,20 +88,38 @@ const clearGithubStateCookie = (res) => {
     });
 };
 
+const OAUTH_FETCH_TIMEOUT_MS = 10000;
+
 const fetchJson = async (url, options, defaultMessage) => {
-    const response = await fetch(url, options);
-    const payload = await response.json().catch(() => null);
+    // Prevent OAuth requests from hanging forever
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), OAUTH_FETCH_TIMEOUT_MS);
 
-    if (!response.ok) {
-        const message =
-            payload?.error_description ||
-            payload?.error ||
-            payload?.message ||
-            defaultMessage;
-        throw new Error(message);
+    try {
+        const response = await fetch(url, {
+            ...(options || {}),
+            signal: controller.signal,
+        });
+        const payload = await response.json().catch(() => null);
+
+        if (!response.ok) {
+            const message =
+                payload?.error_description ||
+                payload?.error ||
+                payload?.message ||
+                defaultMessage;
+            throw new AppError(message, response.status || 502);
+        }
+
+        return payload;
+    } catch (err) {
+        if (err.name === 'AbortError') {
+            throw new AppError('OAuth request timed out.', 504);
+        }
+        throw err;
+    } finally {
+        clearTimeout(timeout);
     }
-
-    return payload;
 };
 
 const exchangeGithubCodeForToken = async ({ code, req }) => {


### PR DESCRIPTION
Fixes #208

## 🛠️ Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing & Validation

### Backend Verification:

* [x] Verified the updated OAuth flow logic locally.
* [x] Confirmed timeout cleanup and graceful abort handling.

### Frontend Verification:

* [ ] Not applicable

## 🔍 Proof of Work

* Added timeout handling to outbound OAuth fetch requests in `auth.controller.js`
* Used `AbortController` to prevent long-running external requests
* Added timeout cleanup using `clearTimeout`
* Preserved the existing OAuth/authentication flow behavior
* Limited changes to a single backend controller file

## ✅ Checklist

* [x] My code follows the code style of this project.
* [x] I have performed a self-review of my code.
* [x] My changes generate no new warnings or errors.

---

Built with ❤️ for **urBackend**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection for OAuth requests to prevent indefinite hangs and provide clearer error messaging during timeout scenarios.
  * Improved error handling for authentication failures with enhanced fallback error message derivation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geturbackend/urBackend/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->