### PR TITLE
atomic RLS filter execution for deletion engine

### DIFF
--- a/apps/public-api/src/__tests__/authorizeWriteOperation.test.js
+++ b/apps/public-api/src/__tests__/authorizeWriteOperation.test.js
@@ -139,6 +139,7 @@ describe('authorizeWriteOperation middleware', () => {
             await authorizeWriteOperation(req, res, next);
 
             expect(res.statusCode).toBe(403);
+            expect(res.body.success).toBe(false);
             expect(res.body.error).toBe('Write blocked for publishable key');
             expect(next).not.toHaveBeenCalled();
         });
@@ -150,6 +151,7 @@ describe('authorizeWriteOperation middleware', () => {
             await authorizeWriteOperation(req, res, next);
 
             expect(res.statusCode).toBe(401);
+            expect(res.body.success).toBe(false);
             expect(res.body.error).toBe('Authentication required');
             expect(next).not.toHaveBeenCalled();
         });
@@ -170,6 +172,7 @@ describe('authorizeWriteOperation middleware', () => {
             await authorizeWriteOperation(req, res, next);
 
             expect(res.statusCode).toBe(403);
+            expect(res.body.success).toBe(false);
             expect(res.body.error).toBe('RLS owner mismatch');
             expect(next).not.toHaveBeenCalled();
         });
@@ -291,6 +294,7 @@ describe('authorizeWriteOperation middleware', () => {
             await authorizeWriteOperation(req, res, next);
 
             expect(res.statusCode).toBe(404);
+            expect(res.body.success).toBe(false);
             expect(res.body.error).toBe('Collection not found');
             expect(next).not.toHaveBeenCalled();
         });
@@ -322,6 +326,7 @@ describe('authorizeWriteOperation middleware', () => {
             await authorizeWriteOperation(req, res, next);
 
             expect(res.statusCode).toBe(403);
+            expect(res.body.success).toBe(false);
             expect(res.body.error).toBe('Insert denied');
             expect(next).not.toHaveBeenCalled();
         });
@@ -338,6 +343,7 @@ describe('authorizeWriteOperation middleware', () => {
             await authorizeWriteOperation(req, res, next);
 
             expect(res.statusCode).toBe(400);
+            expect(res.body.success).toBe(false);
             expect(res.body.error).toBe('Invalid ID format.');
             expect(next).not.toHaveBeenCalled();
         });
@@ -356,6 +362,7 @@ describe('authorizeWriteOperation middleware', () => {
             await authorizeWriteOperation(req, res, next);
 
             expect(res.statusCode).toBe(403);
+            expect(res.body.success).toBe(false);
             expect(res.body.error).toBe('Owner field immutable');
             expect(next).not.toHaveBeenCalled();
         });

--- a/apps/public-api/src/__tests__/authorizeWriteOperation.test.js
+++ b/apps/public-api/src/__tests__/authorizeWriteOperation.test.js
@@ -174,59 +174,8 @@ describe('authorizeWriteOperation middleware', () => {
             expect(next).not.toHaveBeenCalled();
         });
 
-        test('PUT: blocked with 403 when document owner does not match auth userId', async () => {
-            mockLean.mockResolvedValueOnce({ _id: VALID_OID, userId: 'user_xyz' });
-
-            const req = makeReq({
-                method: 'PUT',
-                params: { collectionName: 'posts', id: VALID_OID },
-                authUser: { userId: 'user_abc' }, // different from doc.userId
-                body: { title: 'Updated' },
-            });
-            const res = makeRes();
-
-            await authorizeWriteOperation(req, res, next);
-
-            expect(res.statusCode).toBe(403);
-            expect(res.body.error).toBe('RLS owner mismatch');
-            expect(next).not.toHaveBeenCalled();
-        });
-
-        test('PATCH: blocked with 403 when document owner does not match auth userId', async () => {
-            mockLean.mockResolvedValueOnce({ _id: VALID_OID, userId: 'other_user' });
-
-            const req = makeReq({
-                method: 'PATCH',
-                params: { collectionName: 'posts', id: VALID_OID },
-                authUser: { userId: 'user_abc' },
-                body: { title: 'Patch' },
-            });
-            const res = makeRes();
-
-            await authorizeWriteOperation(req, res, next);
-
-            expect(res.statusCode).toBe(403);
-            expect(res.body.error).toBe('RLS owner mismatch');
-            expect(next).not.toHaveBeenCalled();
-        });
-
-        test('DELETE: blocked with 403 when document owner does not match auth userId', async () => {
-            mockLean.mockResolvedValueOnce({ _id: VALID_OID, userId: 'other_user' });
-
-            const req = makeReq({
-                method: 'DELETE',
-                params: { collectionName: 'posts', id: VALID_OID },
-                authUser: { userId: 'user_abc' },
-                body: {},
-            });
-            const res = makeRes();
-
-            await authorizeWriteOperation(req, res, next);
-
-            expect(res.statusCode).toBe(403);
-            expect(res.body.error).toBe('RLS owner mismatch');
-            expect(next).not.toHaveBeenCalled();
-        });
+        // In the new atomic design, the middleware does not block based on document owner
+        // Instead, it sets req.rlsFilter and lets the controller handle the ownership filter atomically.
     });
 
     // -------------------------------------------------------------------------
@@ -247,9 +196,7 @@ describe('authorizeWriteOperation middleware', () => {
             expect(res.status).not.toHaveBeenCalled();
         });
 
-        test('PUT: allowed when document owner matches auth userId', async () => {
-            mockLean.mockResolvedValueOnce({ _id: VALID_OID, userId: 'user_abc' });
-
+        test('PUT: injects rlsFilter and calls next', async () => {
             const req = makeReq({
                 method: 'PUT',
                 params: { collectionName: 'posts', id: VALID_OID },
@@ -260,13 +207,12 @@ describe('authorizeWriteOperation middleware', () => {
 
             await authorizeWriteOperation(req, res, next);
 
+            expect(req.rlsFilter).toEqual({ userId: 'user_abc' });
             expect(next).toHaveBeenCalledTimes(1);
             expect(res.status).not.toHaveBeenCalled();
         });
 
-        test('DELETE: allowed when document owner matches auth userId', async () => {
-            mockLean.mockResolvedValueOnce({ _id: VALID_OID, userId: 'user_abc' });
-
+        test('DELETE: injects rlsFilter and calls next', async () => {
             const req = makeReq({
                 method: 'DELETE',
                 params: { collectionName: 'posts', id: VALID_OID },
@@ -277,6 +223,7 @@ describe('authorizeWriteOperation middleware', () => {
 
             await authorizeWriteOperation(req, res, next);
 
+            expect(req.rlsFilter).toEqual({ userId: 'user_abc' });
             expect(next).toHaveBeenCalledTimes(1);
             expect(res.status).not.toHaveBeenCalled();
         });
@@ -395,27 +342,9 @@ describe('authorizeWriteOperation middleware', () => {
             expect(next).not.toHaveBeenCalled();
         });
 
-        test('returns 404 when document does not exist on PUT', async () => {
-            mockLean.mockResolvedValueOnce(null);
 
-            const req = makeReq({
-                method: 'PUT',
-                params: { collectionName: 'posts', id: VALID_OID },
-                authUser: { userId: 'user_abc' },
-                body: { title: 'Updated' },
-            });
-            const res = makeRes();
-
-            await authorizeWriteOperation(req, res, next);
-
-            expect(res.statusCode).toBe(404);
-            expect(res.body.error).toBe('Document not found.');
-            expect(next).not.toHaveBeenCalled();
-        });
 
         test('blocks attempt to change ownerField value on PATCH', async () => {
-            mockLean.mockResolvedValueOnce({ _id: VALID_OID, userId: 'user_abc' });
-
             const req = makeReq({
                 method: 'PATCH',
                 params: { collectionName: 'posts', id: VALID_OID },

--- a/apps/public-api/src/middlewares/authorizeWriteOperation.js
+++ b/apps/public-api/src/middlewares/authorizeWriteOperation.js
@@ -99,37 +99,17 @@ for (let i = 0; i < bodyItems.length; i++) {
                 return res.status(400).json({ error: 'Invalid ID format.' });
             }
 
-            const connection = await getConnection(project._id);
-            const Model = getCompiledModel(connection, collectionConfig, project._id, project.resources.db.isExternal);
-            const doc = await Model.findById(id).select(ownerField).lean();
+            req.rlsFilter = { [ownerField]: authUserId };
 
-            if (!doc) {
-                return res.status(404).json({ error: 'Document not found.' });
-            }
-
-            if (ownerField === '_id') {
-                if (String(doc._id) !== authUserId) {
-                    return res.status(403).json({
-                        error: 'RLS owner mismatch',
-                        message: 'You can only modify your own document.'
-                    });
-                }
-            } else {
+            if (method === 'PUT' || method === 'PATCH') {
                 if (
                     req.body &&
                     Object.prototype.hasOwnProperty.call(req.body, ownerField) &&
-                    String(req.body[ownerField]) !== String(doc[ownerField])
+                    String(req.body[ownerField]) !== authUserId
                 ) {
                     return res.status(403).json({
                         error: 'Owner field immutable',
                         message: `${ownerField} cannot be changed under RLS.`
-                    });
-                }
-
-                if (doc[ownerField] === undefined || doc[ownerField] === null || String(doc[ownerField]) !== authUserId) {
-                    return res.status(403).json({
-                        error: 'RLS owner mismatch',
-                        message: 'You can only modify your own document.'
                     });
                 }
             }

--- a/apps/public-api/src/middlewares/authorizeWriteOperation.js
+++ b/apps/public-api/src/middlewares/authorizeWriteOperation.js
@@ -13,12 +13,13 @@ module.exports = async (req, res, next) => {
         const collectionConfig = project.collections.find(c => c.name === collectionName);
 
         if (!collectionConfig) {
-            return res.status(404).json({ error: 'Collection not found' });
+            return res.status(404).json({ success: false, error: 'Collection not found', message: 'The requested collection does not exist.' });
         }
 
         const rls = collectionConfig.rls || {};
         if (!rls.enabled) {
             return res.status(403).json({
+                success: false,
                 error: 'Write blocked for publishable key',
                 message: 'Enable RLS for this collection to allow publishable-key writes.'
             });
@@ -26,6 +27,7 @@ module.exports = async (req, res, next) => {
 
         if (rls.requireAuthForWrite && !req.authUser?.userId) {
             return res.status(401).json({
+                success: false,
                 error: 'Authentication required',
                 message: 'Provide a valid user Bearer token for write operations.'
             });
@@ -34,13 +36,14 @@ module.exports = async (req, res, next) => {
         const modeRaw = rls.mode || 'public-read';
         const allowedModes = new Set(['public-read', 'private', 'owner-write-only']);
         if (!allowedModes.has(modeRaw)) {
-            return res.status(403).json({ error: 'Unsupported RLS mode' });
+            return res.status(403).json({ success: false, error: 'Unsupported RLS mode', message: 'The collection RLS mode is invalid.' });
         }
 
         const ownerField = rls.ownerField || 'userId';
 
         if (!req.authUser?.userId) {
             return res.status(401).json({
+                success: false,
                 error: 'Authentication required',
                 message: 'Provide a valid user Bearer token for write operations.'
             });
@@ -52,6 +55,7 @@ module.exports = async (req, res, next) => {
         if (method === 'POST') {
             if (ownerField === '_id') {
                 return res.status(403).json({
+                    success: false,
                     error: 'Insert denied',
                     message: "RLS ownerField '_id' is not valid for insert ownership checks."
                 });
@@ -61,6 +65,7 @@ module.exports = async (req, res, next) => {
 
           if (bodyItems.length === 0) {
     return res.status(400).json({
+        success: false,
         error: 'Invalid request body',
         message: 'Request body cannot be an empty array.'
     });
@@ -71,8 +76,9 @@ for (let i = 0; i < bodyItems.length; i++) {
 
     if (!item || typeof item !== 'object' || Array.isArray(item)) {
         return res.status(400).json({
+            success: false,
             error: 'Invalid request body',
-           message: `Item at index ${i} must be a valid object`
+            message: `Item at index ${i} must be a valid object`
         });
     }
 
@@ -85,6 +91,7 @@ for (let i = 0; i < bodyItems.length; i++) {
 
     if (String(incomingOwner) !== authUserId) {
         return res.status(403).json({
+            success: false,
             error: 'RLS owner mismatch',
             message: `Item at index ${i} must have ${ownerField} equal to your user id`
         });
@@ -96,7 +103,7 @@ for (let i = 0; i < bodyItems.length; i++) {
 
         if (method === 'PUT' || method === 'PATCH' || method === 'DELETE') {
             if (!id || !mongoose.Types.ObjectId.isValid(id)) {
-                return res.status(400).json({ error: 'Invalid ID format.' });
+                return res.status(400).json({ success: false, error: 'Invalid ID format.', message: 'The provided document ID is not valid.' });
             }
 
             req.rlsFilter = { [ownerField]: authUserId };
@@ -108,6 +115,7 @@ for (let i = 0; i < bodyItems.length; i++) {
                     String(req.body[ownerField]) !== authUserId
                 ) {
                     return res.status(403).json({
+                        success: false,
                         error: 'Owner field immutable',
                         message: `${ownerField} cannot be changed under RLS.`
                     });
@@ -119,6 +127,6 @@ for (let i = 0; i < bodyItems.length; i++) {
 
         return next();
     } catch (err) {
-        return res.status(500).json({ error: err.message });
+        return res.status(500).json({ success: false, error: 'Internal Server Error', message: err.message });
     }
 };


### PR DESCRIPTION
## 🚀 Pull Request Description

I had optimizes the data deletion pipeline by eliminating redundant database reads inside the security middleware. 
Previously, verifying authorship for deletion required pulling the active document into runtime memory stacks first.
Now, the authorization filter is dynamically computed and injected directly into the primary MongoDB query.

Fixes #218 

## 🛠️ Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement (Frontend only)
- [x] ⚙️ Refactor / Chore

## 🧪 Testing & Validation
### Backend Verification:
- [x] I have run `npm test` in the `backend/` directory and all tests passed.
- [x] I have verified the API endpoints using Postman/Thunder Client.
- [x] New unit tests have been added (if applicable).

### Frontend Verification:
- [x] I have run `npm run lint` in the `frontend/` directory.
- [ ] Verified the UI changes on different screen sizes (Responsive).
- [ ] Checked for any console errors in the browser dev tools.

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or errors.
- [ ] I have updated the documentation (README/Docs) accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened ownership checks for write actions so users can only modify or delete their own records; protected owner fields are now immutable during updates.
  * Standardized error responses with explicit failure indicators and clearer messages for invalid IDs, bad request bodies, and authorization failures.

* **Tests**
  * Updated tests to reflect the new ownership-enforcement behavior and standardized response format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/geturbackend/urBackend/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->