### PR TITLE
fix(dashboard-api): enforce SameSite=Lax on all cookies to prevent CSRF attacks

### DIFF
--- a/apps/dashboard-api/src/app.js
+++ b/apps/dashboard-api/src/app.js
@@ -70,7 +70,7 @@ const csrfProtection = csurf({
     cookie: {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax'
+        sameSite: 'lax'
     } 
 });
 

--- a/apps/dashboard-api/src/controllers/auth.controller.js
+++ b/apps/dashboard-api/src/controllers/auth.controller.js
@@ -44,7 +44,7 @@ const getCookieOptions = () => {
         httpOnly: true,
         expires: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
         secure: process.env.NODE_ENV === 'production',
-        sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax'
+        sameSite: 'lax'
     };
 
     if (process.env.NODE_ENV === 'production') {
@@ -83,7 +83,7 @@ const clearGithubStateCookie = (res) => {
     res.cookie(GITHUB_STATE_COOKIE, 'none', {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+        sameSite: 'lax',
         expires: new Date(Date.now() + 10 * 1000),
     });
 };
@@ -354,7 +354,7 @@ module.exports.startGithubAuth = async (req, res) => {
     res.cookie(GITHUB_STATE_COOKIE, state, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',
-        sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+        sameSite: 'lax',
         expires: new Date(Date.now() + GITHUB_STATE_TTL_MS),
     });
 
@@ -565,13 +565,13 @@ module.exports.resetPassword = async (req, res) => {
                 expires: new Date(Date.now() + 10 * 1000),
                 httpOnly: true,
                 secure: process.env.NODE_ENV === 'production',
-                sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax'
+                sameSite: 'lax'
             })
             .cookie('refreshToken', 'none', {
                 expires: new Date(Date.now() + 10 * 1000),
                 httpOnly: true,
                 secure: process.env.NODE_ENV === 'production',
-                sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax'
+                sameSite: 'lax'
             })
             .json({ message: "Password reset successfully. Please log in with your new password." });
     } catch (err) {
@@ -597,13 +597,13 @@ module.exports.logout = async (req, res) => {
             expires: new Date(Date.now() + 10 * 1000),
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax'
+            sameSite: 'lax'
         });
         res.cookie('refreshToken', 'none', {
             expires: new Date(Date.now() + 10 * 1000),
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
-            sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax'
+            sameSite: 'lax'
         });
 
         res.status(200).json({ success: true, message: "Logged out successfully" });


### PR DESCRIPTION
## Summary
Fixes #239 - Dashboard API CSRF vulnerability

## Problem
Auth middleware reads JWT from \eq.cookies.accessToken\ as primary source. The cookies were set with \SameSite=None\ in production, allowing browsers to attach them on any cross-origin request.

## Solution
Changed all dashboard-api cookies to use \SameSite=Lax\ consistently across all environments. This prevents cookies from being sent on cross-origin subresource requests while still allowing top-level navigations.

### Affected cookies:
- \ccessToken\, \efreshToken\, \_csrf\, \dashboardGithubOauthState\

### Files changed:
- \pps/dashboard-api/src/app.js\
- \pps/dashboard-api/src/controllers/auth.controller.js\

## Verification
- All 14 auth middleware tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication and CSRF protection cookie configurations to enforce consistent security settings across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->