### PR TITLE
fix: apply authLimiter to OTP and password reset routes

### DIFF
--- a/apps/dashboard-api/src/routes/auth.js
+++ b/apps/dashboard-api/src/routes/auth.js
@@ -31,6 +31,13 @@ const dashboardLimiter = rateLimit({
 router.post('/register', authLimiter, register);
 
 router.post('/login', authLimiter, login);
+
+router.post('/send-otp', authLimiter, sendOtp);
+router.post('/verify-otp', authLimiter, verifyOtp);
+
+router.post('/forgot-password', authLimiter, forgotPassword);
+router.post('/reset-password', authLimiter, resetPassword);
+
 router.get('/github/start', startGithubAuth);
 router.get('/github/callback', handleGithubCallback);
 
@@ -39,12 +46,6 @@ router.use(dashboardLimiter);
 router.put('/change-password', authorization, changePassword);
 
 router.delete('/delete-account', authorization, deleteAccount);
-
-router.post('/send-otp', authLimiter, sendOtp);
-router.post('/verify-otp', authLimiter, verifyOtp);
-
-router.post('/forgot-password', authLimiter, forgotPassword);
-router.post('/reset-password', authLimiter, resetPassword);
 
 router.post('/refresh-token', refreshToken);
 router.post('/logout', authorization, logout);

--- a/apps/dashboard-api/src/routes/auth.js
+++ b/apps/dashboard-api/src/routes/auth.js
@@ -40,11 +40,11 @@ router.put('/change-password', authorization, changePassword);
 
 router.delete('/delete-account', authorization, deleteAccount);
 
-router.post('/send-otp', sendOtp);
-router.post('/verify-otp', verifyOtp);
+router.post('/send-otp', authLimiter, sendOtp);
+router.post('/verify-otp', authLimiter, verifyOtp);
 
-router.post('/forgot-password', forgotPassword);
-router.post('/reset-password', resetPassword);
+router.post('/forgot-password', authLimiter, forgotPassword);
+router.post('/reset-password', authLimiter, resetPassword);
 
 router.post('/refresh-token', refreshToken);
 router.post('/logout', authorization, logout);


### PR DESCRIPTION
## Summary

This PR applies `authLimiter` to OTP and password reset endpoints that were previously protected only by `dashboardLimiter`.

### Changes Made

* Added `authLimiter` to:

  * `/send-otp`
  * `/verify-otp`
  * `/forgot-password`
  * `/reset-password`

### Why

These endpoints were inheriting `dashboardLimiter` (1000 requests / 15 min), making them vulnerable to:

* OTP brute-force attempts
* OTP email spam
* Password reset abuse
* User enumeration attacks

Applying `authLimiter` aligns them with the same protection already used for login and registration endpoints.

Fixes #246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Applied rate limiting to sensitive authentication endpoints including OTP sending and verification, password recovery requests, and password reset operations to prevent abuse and enhance system stability and security against unauthorized access attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->