### PR TITLE
fix(web-dashboard): show string schema fields in RLS owner dropdown

### DIFF
--- a/apps/web-dashboard/src/pages/Database.jsx
+++ b/apps/web-dashboard/src/pages/Database.jsx
@@ -486,9 +486,11 @@ export default function Database() {
                             style={{ width: '100%', height: '40px', fontSize: '0.85rem' }}
                           >
                               <option value="userId">userId (Default)</option>
-                                {activeCollection?.model?.filter(f => String(f?.type || '').toLowerCase() === 'string').map(f => (
-                                  <option key={f.key} value={f.key}>{f.key}</option>
-                              ))}
+                                {activeCollection?.model
+                                  ?.filter(f => String(f?.type || '').toLowerCase() === 'string' && String(f?.key || '').toLowerCase() !== 'userid')
+                                  .map(f => (
+                                    <option key={f.key} value={f.key}>{f.key}</option>
+                                ))}
                           </select>
                           <p style={{ fontSize: '0.7rem', color: 'var(--color-text-muted)', marginTop: '8px' }}>
                               The field in your document that stores the creator's user ID.

--- a/apps/web-dashboard/src/pages/Database.jsx
+++ b/apps/web-dashboard/src/pages/Database.jsx
@@ -486,7 +486,7 @@ export default function Database() {
                             style={{ width: '100%', height: '40px', fontSize: '0.85rem' }}
                           >
                               <option value="userId">userId (Default)</option>
-                              {activeCollection?.model?.filter(f => f.type === 'STRING').map(f => (
+                                {activeCollection?.model?.filter(f => String(f?.type || '').toLowerCase() === 'string').map(f => (
                                   <option key={f.key} value={f.key}>{f.key}</option>
                               ))}
                           </select>


### PR DESCRIPTION
## Summary

Fixes #262 

This PR fixes an RLS settings bug in the Database screen where the **Ownership Field** dropdown only showed `userId` and did not include valid string fields from the selected collection model (for example, `ownerId`, `createdBy`).

## Problem

In the RLS dialog, the ownership field options were filtered using a strict type comparison that expected one casing format only.  
As a result, schema fields typed as `String` were excluded from the dropdown, making it look like only `userId` was supported.

## Solution

Updated the ownership-field filter logic to normalize type values before comparison.  
This allows string fields to be detected regardless of casing format and correctly displayed as selectable options in the dropdown.

## User Impact

- Admins can now choose existing string schema fields for RLS ownership.
- The UI now matches backend behavior, which already supports configurable owner fields.
- No API contract or database migration changes were required.

## Scope

- Frontend only
- Single-file change in the Database page RLS dialog
- Non-breaking bug fix

## Validation

- Ran lint for the web dashboard successfully.
- Manually verified that string model fields now appear in the Ownership Field dropdown when RLS is enabled.

## Notes

This change improves correctness and removes a confusing UI mismatch where backend capability existed but was hidden by the frontend filter.

## image 

<img width="1911" height="968" alt="image" src="https://github.com/user-attachments/assets/f39d3688-96f6-4948-9e13-158e446e5c86" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the RLS dialog's Ownership Field selection to properly recognize all available string field options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->